### PR TITLE
Goesdump enhancement (Fix #11 opensatelliteproject/goesdump)

### DIFF
--- a/XRIT/Log/Facility.cs
+++ b/XRIT/Log/Facility.cs
@@ -10,14 +10,14 @@
         News=7,
         UUCP=8,
         Cron=9,
-        Local0=10,
-        Local1=11,
-        Local2=12,
-        Local3=13,
-        Local4=14,
-        Local5=15,
-        Local6=16,
-        Local7=17
+        Local0=16,
+        Local1=17,
+        Local2=18,
+        Local3=19,
+        Local4=20,
+        Local5=21,
+        Local6=22,
+        Local7=23
     }
 }
 

--- a/XRIT/Log/Message.cs
+++ b/XRIT/Log/Message.cs
@@ -3,7 +3,7 @@
 namespace OpenSatelliteProject.Log {
 
     public class Message {
-        public int Facility { get; set; }
+        public string Facility { get; set; }
 
         public int Level { get; set; }
 
@@ -15,29 +15,29 @@ namespace OpenSatelliteProject.Log {
             Name = "OpenSatelliteProject";
         }
 
-        public Message(int facility, int level, string text) {
+        public Message(string facility, int level, string text) {
             this.Facility = facility;
             this.Level = level;
             this.Text = text;
             this.Name = "OpenSatelliteProject";
         }
 
-        public Message(Facility facility, Level level, string text) {
-            this.Facility = (int)facility;
+        public Message(string facility, Level level, string text) {
+            this.Facility = facility;
             this.Level = (int)level;
             this.Text = text;
             this.Name = "OpenSatelliteProject";
         }
 
-        public Message(int facility, int level, string name, string text) {
+        public Message(string facility, int level, string name, string text) {
             this.Facility = facility;
             this.Level = level;
             this.Text = text;
             this.Name = name;
         }
 
-        public Message(Facility facility, Level level, string name, string text) {
-            this.Facility = (int)facility;
+        public Message(string facility, Level level, string name, string text) {
+            this.Facility = facility;
             this.Level = (int)level;
             this.Text = text;
             this.Name = name;

--- a/XRIT/Log/SyslogClient.cs
+++ b/XRIT/Log/SyslogClient.cs
@@ -1,19 +1,20 @@
 ﻿using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Collections.Generic;
 
 namespace OpenSatelliteProject.Log {
     public class SyslogClient {
-        private IPHostEntry ipHostInfo;
-        private IPAddress ipAddress;
-        private IPEndPoint ipLocalEndPoint;
-        private UdpClient udpClient;
+        private static IPHostEntry ipHostInfo;
+        private static IPAddress ipAddress;
+        private static IPEndPoint ipLocalEndPoint;
+        private static UdpClient udpClient;
+        private static Dictionary<string,Facility> FacilityMap;
+        public static int Port { get; set; }
+        public static string SysLogServerIp { get; set; }
+        public static bool IsActive { get; set; }
 
-        public int Port { get; set; }
-        public string SysLogServerIp { get; set; }
-        public bool IsActive { get; set; }
-
-        public SyslogClient() {
+        static SyslogClient() {
             if (!Tools.LLTools.IsLinux) {
                 throw new ArgumentException("Syslog only works on Linux");
             }
@@ -23,7 +24,7 @@ namespace OpenSatelliteProject.Log {
             ipLocalEndPoint = new IPEndPoint(ipAddress, 0);
             udpClient= new UdpClient(ipLocalEndPoint);
             Port = 514;
-            SysLogServerIp = "localhost";
+            InitFacilityMap();
         }
 
         public void Close() {
@@ -40,12 +41,36 @@ namespace OpenSatelliteProject.Log {
             }
 
             if (IsActive) {
-                int priority = message.Facility * 8 + message.Level;
+                int priority = (int)FacilityMap[message.Facility] * 8 + message.Level;
                 string msg = System.String.Format("<{0}>{1} {2} {3}", priority, DateTime.Now.ToString("MMM dd HH:mm:ss"), "XRIT", message.Text);
                 byte[] bytes = System.Text.Encoding.ASCII.GetBytes(msg);
                 udpClient.Send(bytes, bytes.Length);
             }
         }
+
+        public static void InitFacilityMap() {
+            FacilityMap = new Dictionary<string, Facility>();
+
+            FacilityMap["LOG_KERNEL"] = Facility.Kernel;
+            FacilityMap["LOG_USER"]   = Facility.User;
+            FacilityMap["LOG_MAIL"]   = Facility.Mail;
+            FacilityMap["LOG_DAEMON"] = Facility.Daemon;
+            FacilityMap["LOG_AUTH"]   = Facility.Auth;
+            FacilityMap["LOG_SYSLOG"] = Facility.Syslog;
+            FacilityMap["LOG_LPR"]    = Facility.Lpr;
+            FacilityMap["LOG_NEWS"]   = Facility.News;
+            FacilityMap["LOG_UUCP"]   = Facility.UUCP;
+            FacilityMap["LOG_CRON"]   = Facility.Cron;
+            FacilityMap["LOG_LOCAL0"] = Facility.Local0;
+            FacilityMap["LOG_LOCAL1"] = Facility.Local1;
+            FacilityMap["LOG_LOCAL2"] = Facility.Local2;
+            FacilityMap["LOG_LOCAL3"] = Facility.Local3;
+            FacilityMap["LOG_LOCAL4"] = Facility.Local4;
+            FacilityMap["LOG_LOCAL5"] = Facility.Local5;
+            FacilityMap["LOG_LOCAL6"] = Facility.Local6;
+            FacilityMap["LOG_LOCAL7"] = Facility.Local7;
+        }
+
     }
 }
 

--- a/XRIT/Log/SyslogClient.cs
+++ b/XRIT/Log/SyslogClient.cs
@@ -34,7 +34,7 @@ namespace OpenSatelliteProject.Log {
             }
         }
 
-        public void Send(Message message) {
+        public static void Send(Message message) {
             if (!IsActive) {
                 udpClient.Connect(SysLogServerIp, Port);
                 IsActive = true;
@@ -48,7 +48,7 @@ namespace OpenSatelliteProject.Log {
             }
         }
 
-        public static void InitFacilityMap() {
+        private static void InitFacilityMap() {
             FacilityMap = new Dictionary<string, Facility>();
 
             FacilityMap["LOG_KERNEL"] = Facility.Kernel;

--- a/goesdump/HeadlessMain.cs
+++ b/goesdump/HeadlessMain.cs
@@ -36,7 +36,6 @@ namespace OpenSatelliteProject {
 
         private static List<ConsoleMessage> messageList = new List<ConsoleMessage>();
         private static Mutex messageListMutex = new Mutex();
-        private SyslogClient syslog = new SyslogClient();
 
         private bool running = false;
 
@@ -96,7 +95,7 @@ namespace OpenSatelliteProject {
 
             if (LLTools.IsLinux) {
                 try {
-                    syslog.Send(new Message(config.SysLogFacility, Level.Information, "Your syslog connection is working! OpenSatelliteProject is enabled to send logs."));
+                    SyslogClient.Send(new Message(config.SysLogFacility, Level.Information, "Your syslog connection is working! OpenSatelliteProject is enabled to send logs."));
                 } catch (WebSocketException) {
                     UIConsole.GlobalConsole.Warn("Your syslog is not enabled to receive UDP request. Please refer to https://opensatelliteproject.github.io/OpenSatelliteProject/");
                 }

--- a/goesdump/Main.cs
+++ b/goesdump/Main.cs
@@ -8,6 +8,7 @@ using Microsoft.Xna.Framework.Input;
 using System.Threading;
 using System.IO;
 using OpenSatelliteProject.PacketData.Enums;
+using OpenSatelliteProject.Log;
 
 namespace OpenSatelliteProject {
     /// <summary>
@@ -21,6 +22,7 @@ namespace OpenSatelliteProject {
         private ImageManager NHImageManager;
         private ImageManager SHImageManager;
         private ImageManager USImageManager;
+        private SyslogClient syslog;
 
         GraphicsDeviceManager graphics;
         SpriteBatch spriteBatch;
@@ -63,6 +65,8 @@ namespace OpenSatelliteProject {
             config.GenerateVisibleImages = config.GenerateVisibleImages;
             config.GenerateWaterVapourImages = config.GenerateWaterVapourImages;
             config.MaxGenerateRetry = config.MaxGenerateRetry;
+            config.SysLogServer = config.SysLogServer;
+            config.SysLogFacility = config.SysLogFacility;
             config.Save();
             #endregion
 
@@ -92,6 +96,8 @@ namespace OpenSatelliteProject {
             Connector.ChannelDataServerPort = config.ChannelDataServerPort;
             Connector.StatisticsServerPort = config.StatisticsServerPort;
             Connector.ConstellationServerPort = config.ConstellationServerPort;
+
+            SyslogClient.SysLogServerIp = config.SysLogServer;
 
             if (config.GenerateFDFalseColor) {
                 string fdFolder = PacketManager.GetFolderByProduct(NOAAProductID.SCANNER_DATA_1, (int)ScannerSubProduct.INFRARED_FULLDISK);

--- a/goesdump/Models/ProgConfig.cs
+++ b/goesdump/Models/ProgConfig.cs
@@ -140,6 +140,22 @@ namespace OpenSatelliteProject {
             set { this["EnableEMWIN"] = value; }
         }
         #endregion
+
+        #region Syslog Configuration
+        [UserScopedSettingAttribute()]
+        [DefaultSettingValueAttribute("localhost")]
+        public string SysLogServer {
+            get { return (string)this["SysLogServer"]; }
+            set { this["SysLogServer"] = value; }
+        }
+
+        [UserScopedSettingAttribute()]
+        [DefaultSettingValueAttribute("LOG_USER")]
+        public string SysLogFacility {
+            get { return (string)this["SysLogFacility"]; }
+            set { this["SysLogFacility"] = value; }
+        }
+        #endregion
     }
 }
 

--- a/goesdump/UIComponents/UIConsole.cs
+++ b/goesdump/UIComponents/UIConsole.cs
@@ -142,7 +142,7 @@ namespace OpenSatelliteProject {
 
             if (syslog != null) {
                 try {
-                    syslog.Send(new Message(config.SysLogFacility, Level.Information, cm.Message));
+                    SyslogClient.Send(new Message(config.SysLogFacility, Level.Information, cm.Message));
                 } catch (SocketException) {
                     // Syslog not configured, ignore.
                 }
@@ -166,7 +166,7 @@ namespace OpenSatelliteProject {
 
             if (syslog != null) {
                 try {
-                    syslog.Send(new Message(config.SysLogFacility, Level.Warning, cm.Message));
+                    SyslogClient.Send(new Message(config.SysLogFacility, Level.Warning, cm.Message));
                 } catch (SocketException) {
                     // Syslog not configured, ignore.
                 }
@@ -190,7 +190,7 @@ namespace OpenSatelliteProject {
 
             if (syslog != null) {
                 try {
-                    syslog.Send(new Message(config.SysLogFacility, Level.Error, cm.Message));
+                    SyslogClient.Send(new Message(config.SysLogFacility, Level.Error, cm.Message));
                 } catch (SocketException) {
                     // Syslog not configured, ignore.
                 }
@@ -214,7 +214,7 @@ namespace OpenSatelliteProject {
 
             if (syslog != null) {
                 try {
-                    syslog.Send(new Message(config.SysLogFacility, Level.Debug, cm.Message));
+                    SyslogClient.Send(new Message(config.SysLogFacility, Level.Debug, cm.Message));
                 } catch (SocketException) {
                     // Syslog not configured, ignore.
                 }

--- a/goesdump/UIComponents/UIConsole.cs
+++ b/goesdump/UIComponents/UIConsole.cs
@@ -26,15 +26,14 @@ namespace OpenSatelliteProject {
     #endif
         public static UIConsole GlobalConsole;
 
-        public SyslogClient syslog;
-
         public bool LogConsole { get; set; }
         #if !HEADLESS
         public Vector2 Position { get; set; }
         public SpriteFont Font { get; set; }
         #endif
         private Mutex messageMutex;
-
+        private static ProgConfig config = new ProgConfig();
+        private static SyslogClient syslog = new SyslogClient();
         public delegate void ConsoleEvent(ConsoleMessage data);
 
         public event ConsoleEvent MessageAvailable;
@@ -64,10 +63,7 @@ namespace OpenSatelliteProject {
             messages = new List<ConsoleMessage>();
             Position = new Vector2(0, 0);
             #endif
-
-            if (Tools.LLTools.IsLinux) {
-                syslog = new SyslogClient();
-            }
+            SyslogClient.SysLogServerIp = config.SysLogServer;
         }
         #if !HEADLESS
         public float MaxHeight {
@@ -146,7 +142,7 @@ namespace OpenSatelliteProject {
 
             if (syslog != null) {
                 try {
-                    syslog.Send(new Message(Facility.User, Level.Information, cm.Message));
+                    syslog.Send(new Message(config.SysLogFacility, Level.Information, cm.Message));
                 } catch (SocketException) {
                     // Syslog not configured, ignore.
                 }
@@ -170,7 +166,7 @@ namespace OpenSatelliteProject {
 
             if (syslog != null) {
                 try {
-                    syslog.Send(new Message(Facility.User, Level.Warning, cm.Message));
+                    syslog.Send(new Message(config.SysLogFacility, Level.Warning, cm.Message));
                 } catch (SocketException) {
                     // Syslog not configured, ignore.
                 }
@@ -194,7 +190,7 @@ namespace OpenSatelliteProject {
 
             if (syslog != null) {
                 try {
-                    syslog.Send(new Message(Facility.User, Level.Error, cm.Message));
+                    syslog.Send(new Message(config.SysLogFacility, Level.Error, cm.Message));
                 } catch (SocketException) {
                     // Syslog not configured, ignore.
                 }
@@ -218,7 +214,7 @@ namespace OpenSatelliteProject {
 
             if (syslog != null) {
                 try {
-                    syslog.Send(new Message(Facility.User, Level.Debug, cm.Message));
+                    syslog.Send(new Message(config.SysLogFacility, Level.Debug, cm.Message));
                 } catch (SocketException) {
                     // Syslog not configured, ignore.
                 }


### PR DESCRIPTION
Adds 2 new keywords to the config file:

"SysLogServer" - The host name or IP address or the remote syslog server.
                            Default is "localhost".

"SysLogFacility" - The syslog facility (see <sys/syslog.h>) which should be
                             used in syslog messages.  Default is "LOG_USER".