### PR TITLE
Test branch for HRIT

### DIFF
--- a/XRIT/DCS/DCSHeader.cs
+++ b/XRIT/DCS/DCSHeader.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+
+namespace OpenSatelliteProject.DCS {
+    public class DCSHeader {
+
+        public string Address { get; set; }
+        public DateTime DateTime { get; set; }
+        public string Status { get; set; }
+        public int Signal { get; set; }
+        public int FrequencyOffset { get; set; }
+        public string ModIndexNormal { get; set; }
+        public string DataQualNominal { get; set; }
+        public string Channel { get; set; }
+        public string SourceCode { get; set; }
+
+        public DCSHeader(string header) {
+            try { 
+                Address = header.Substring(0, 8);
+                ModIndexNormal =  "" + header[25];
+                DataQualNominal =  "" + header[26];
+                Channel = header.Substring(27, 4);
+                SourceCode = header.Substring(31, 2);
+                Status = "" + header[20];
+
+                int year = int.Parse(header.Substring(9, 2));
+                int dayOfYear = int.Parse(header.Substring(11, 3));
+                int hour = int.Parse(header.Substring(14, 2));
+                int min = int.Parse(header.Substring(16, 2));
+                int second = int.Parse(header.Substring(18, 2));
+                DateTime = new DateTime(2000 + year, 1, 1, hour, min, second);
+                DateTime = DateTime.AddDays(dayOfYear);
+
+                Signal = int.Parse(header.Substring(21, 2));
+                FrequencyOffset = int.Parse(header.Substring(23, 2));
+            } catch(Exception e) {
+                Console.WriteLine("Invalid header: {0}", e);
+            }
+        }
+
+        public DCSHeader(byte[] header) : this(Encoding.ASCII.GetString(header.Take(33).ToArray())) {
+            
+        }
+    }
+}
+

--- a/XRIT/DCS/DCSParser.cs
+++ b/XRIT/DCS/DCSParser.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using OpenSatelliteProject.Tools;
+using System.IO;
+using System.Linq;
+
+namespace OpenSatelliteProject.DCS {
+    public static class DCSParser {
+
+
+        public static List<DCSHeader> parseDCS(string filename) {
+            List<DCSHeader> headers = new List<DCSHeader>();
+            var header = FileParser.GetHeaderFromFile(filename);
+            var dataOffset = header.PrimaryHeader.HeaderLength;
+            int dataSize;
+            byte[] fileData;
+
+            using (var fs = File.OpenRead(filename)) {
+                fs.Seek(dataOffset, SeekOrigin.Begin);
+                dataSize = (int)(fs.Length - dataOffset);
+                fileData = new byte[dataSize];
+                fs.Read(fileData, 0, dataSize);
+            }
+
+            //byte[] baseHeader = fileData.Take(64).ToArray();
+            fileData = fileData.Skip(64).ToArray();
+
+            List<byte[]> dcs = new List<byte[]>();
+
+            int lastPos = 0;
+            int pos = 0;
+            while (pos < fileData.Length - 3) {
+                if (fileData[pos] == 0x02 && fileData[pos + 1] == 0x02 && fileData[pos + 2] == 0x18) {
+                    Console.WriteLine("Found segment at {0}", pos);
+                    byte[] segment = fileData.Skip(lastPos).Take(pos - lastPos - 3).ToArray();
+                    dcs.Add(segment);
+                    pos += 3;
+                    lastPos = pos;
+                } else {
+                    pos++;
+                }
+            }
+
+            dcs.ForEach(a => {
+                if (a.Length > 33) {
+                    DCSHeader h = new DCSHeader(a);
+                    headers.Add(h);
+                }
+            });
+
+            return headers;
+        }
+    }
+}
+

--- a/XRIT/Models/OrganizerData.cs
+++ b/XRIT/Models/OrganizerData.cs
@@ -16,7 +16,7 @@ namespace OpenSatelliteProject {
             Columns = -1;
             PixelAspect = -1;
             StartColumn = 0;
-            MaxSegments = 0;
+            MaxSegments = 1;
         }
 
         public bool IsComplete { get { return Segments.Count == MaxSegments; }}

--- a/XRIT/PacketData/EMWINHeader.cs
+++ b/XRIT/PacketData/EMWINHeader.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Globalization;
+
+namespace OpenSatelliteProject.PacketData {
+    public class EMWINHeader {
+
+        public string Filename { get; }
+        public int PartNumber { get; }
+        public int PartTotal { get; }
+        public int CS { get; }
+        public string DateTime { get; }
+
+        public EMWINHeader(string header) {
+            if (header[0] != '/') {
+                throw new InvalidOperationException(string.Format("Invalid header: {0}", header));
+            }
+            //UIConsole.GlobalConsole.Debug("EMWIN Header: " + header);
+            ///PFMISDCPNI.TXT/PN1     /PT1     /CS11024  /FD02/12/2017 07:27:29 PM  
+            try {
+                Filename = header.Substring(1, 14);
+                PartNumber = int.Parse(header.Substring(18, 6).Trim());
+                PartTotal = int.Parse(header.Substring(27, 6).Trim());
+                CS = int.Parse(header.Substring(36, 7).Trim());
+                this.DateTime = header.Substring(46, 22).Trim();
+            } catch (Exception e) {
+                Console.WriteLine("ERROR Parsing header \"{0}\": {1}", header, e);
+                Filename = "PFFILLFILE.TXT"; // To EMWIN Ingestor skip corrupted header
+            }
+        }
+    }
+}

--- a/XRIT/PacketData/EmwinFile.cs
+++ b/XRIT/PacketData/EmwinFile.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace OpenSatelliteProject.PacketData {
+    public class EmwinFile {
+
+        public string Output { get; set; }
+
+        public int Parts { get; set; }
+
+        public int Received { get; set; }
+    }
+}

--- a/XRIT/PacketData/Enums/CompressionType.cs
+++ b/XRIT/PacketData/Enums/CompressionType.cs
@@ -5,7 +5,8 @@ namespace OpenSatelliteProject.PacketData {
         NO_COMPRESSION = 0,
         LRIT_RICE = 1,
         JPEG = 2,
-        GIF = 5
+        GIF = 5,
+        ZIP = 10
     }
 }
 

--- a/XRIT/PacketData/Enums/NOAAProductID.cs
+++ b/XRIT/PacketData/Enums/NOAAProductID.cs
@@ -7,8 +7,10 @@ namespace OpenSatelliteProject.PacketData.Enums {
         OTHER_SATELLITES_2 = 4,
         WEATHER_DATA = 6,
         DCS = 8,
+        HRIT_EMWIN_TEXT = 9,
         SCANNER_DATA_1 = 13,
         SCANNER_DATA_2 = 15,
+        SCANNER_DATA_3 = 16,
         EMWIN = 42
     }
 }

--- a/XRIT/PacketData/Enums/NOAAProductID.cs
+++ b/XRIT/PacketData/Enums/NOAAProductID.cs
@@ -8,10 +8,11 @@ namespace OpenSatelliteProject.PacketData.Enums {
         WEATHER_DATA = 6,
         DCS = 8,
         HRIT_EMWIN_TEXT = 9,
-        SCANNER_DATA_1 = 13,
-        SCANNER_DATA_2 = 15,
-        SCANNER_DATA_3 = 16,
-        EMWIN = 42
+        GOES13_ABI = 13,
+        GOES15_ABI = 15,
+        GOES16_ABI = 16,
+        EMWIN = 42,
+        HIMAWARI8_ABI = 43
     }
 }
 

--- a/XRIT/PacketData/MSDU.cs
+++ b/XRIT/PacketData/MSDU.cs
@@ -74,8 +74,7 @@ namespace OpenSatelliteProject.PacketData {
 
         public void addDataBytes(byte[] data) {            
             if (data.Length + Data.Length > PacketLength + 2) {
-                Console.WriteLine("(MSDU) Overflow in MSDU--!");
-                Console.WriteLine(Environment.StackTrace);
+                Console.WriteLine("Overflow in MSDU!");
             }
             byte[] newData = new byte[Data.Length + data.Length];
             Array.Copy(Data, newData, Data.Length);

--- a/XRIT/PacketData/MSDU.cs
+++ b/XRIT/PacketData/MSDU.cs
@@ -73,9 +73,9 @@ namespace OpenSatelliteProject.PacketData {
         #region Methods
 
         public void addDataBytes(byte[] data) {            
-            if (data.Length + Data.Length > PacketLength + 2) {
+            /*if (data.Length + Data.Length > PacketLength + 2) {
                 Console.WriteLine("Overflow in MSDU!");
-            }
+            }*/
             byte[] newData = new byte[Data.Length + data.Length];
             Array.Copy(Data, newData, Data.Length);
             Array.Copy(data, 0, newData, Data.Length, data.Length);

--- a/XRIT/PacketData/Presets.cs
+++ b/XRIT/PacketData/Presets.cs
@@ -29,6 +29,8 @@ namespace OpenSatelliteProject.PacketData {
 
             noaaProducts.Add((int)NOAAProductID.DCS, new NOAAProduct(NOAAProductID.DCS, "DCS"));
 
+            noaaProducts.Add((int)NOAAProductID.HRIT_EMWIN_TEXT, new NOAAProduct(NOAAProductID.HRIT_EMWIN_TEXT, "HRIT EMWIN TEXT"));
+
             noaaProducts.Add((int)NOAAProductID.SCANNER_DATA_1, new NOAAProduct(NOAAProductID.SCANNER_DATA_1, "Scanner Image", new Dictionary<int, NOAASubproduct>() { // So far, only received GOES 13 images. Coecidence?
                 { (int) ScannerSubProduct.NONE,                         new NOAASubproduct(ScannerSubProduct.NONE,                          "None") },
                 { (int) ScannerSubProduct.INFRARED_FULLDISK,            new NOAASubproduct(ScannerSubProduct.INFRARED_FULLDISK,             "Infrared Full Disk") },
@@ -66,6 +68,29 @@ namespace OpenSatelliteProject.PacketData {
                 { (int) ScannerSubProduct.WATERVAPOUR_UNITEDSTATES,     new NOAASubproduct(ScannerSubProduct.WATERVAPOUR_UNITEDSTATES,      "Water Vapour United States") },
                 { (int) ScannerSubProduct.WATERVAPOUR_AREA_OF_INTEREST, new NOAASubproduct(ScannerSubProduct.WATERVAPOUR_AREA_OF_INTEREST,  "Water Vapour Area of Interest") }
             }));
+
+            noaaProducts.Add((int)NOAAProductID.SCANNER_DATA_3, new NOAAProduct(NOAAProductID.SCANNER_DATA_3, "GOES 16 ABI", new Dictionary<int, NOAASubproduct>() {
+                { (int) ScannerSubProduct.NONE,                         new NOAASubproduct(ScannerSubProduct.NONE,                          "None") },
+                {                            1,                         new NOAASubproduct(                     1,                          "Channel 1") },
+                {                            2,                         new NOAASubproduct(                     2,                          "Channel 2") },
+                {                            3,                         new NOAASubproduct(                     3,                          "Channel 3") },
+                {                            4,                         new NOAASubproduct(                     4,                          "Channel 4") },
+                {                            5,                         new NOAASubproduct(                     5,                          "Channel 5") },
+                {                            6,                         new NOAASubproduct(                     6,                          "Channel 6") },
+                {                            7,                         new NOAASubproduct(                     7,                          "Channel 7") },
+                {                            8,                         new NOAASubproduct(                     8,                          "Channel 8") },
+                {                            9,                         new NOAASubproduct(                     9,                          "Channel 9") },
+                {                           10,                         new NOAASubproduct(                    10,                          "Channel 10") },
+                {                           11,                         new NOAASubproduct(                    11,                          "Channel 11") },
+                {                           12,                         new NOAASubproduct(                    12,                          "Channel 12") },
+                {                           13,                         new NOAASubproduct(                    13,                          "Channel 13") },
+                {                           14,                         new NOAASubproduct(                    14,                          "Channel 14") },
+                {                           15,                         new NOAASubproduct(                    15,                          "Channel 15") },
+                {                           16,                         new NOAASubproduct(                    16,                          "Channel 16") }
+            }));
+
+
+
 
             noaaProducts.Add((int)NOAAProductID.EMWIN, new NOAAProduct(NOAAProductID.EMWIN, "EMWIN"));
         }

--- a/XRIT/PacketData/Presets.cs
+++ b/XRIT/PacketData/Presets.cs
@@ -31,7 +31,7 @@ namespace OpenSatelliteProject.PacketData {
 
             noaaProducts.Add((int)NOAAProductID.HRIT_EMWIN_TEXT, new NOAAProduct(NOAAProductID.HRIT_EMWIN_TEXT, "HRIT EMWIN TEXT"));
 
-            noaaProducts.Add((int)NOAAProductID.SCANNER_DATA_1, new NOAAProduct(NOAAProductID.SCANNER_DATA_1, "Scanner Image", new Dictionary<int, NOAASubproduct>() { // So far, only received GOES 13 images. Coecidence?
+            noaaProducts.Add((int)NOAAProductID.GOES13_ABI, new NOAAProduct(NOAAProductID.GOES13_ABI, "GOES 13 ABI", new Dictionary<int, NOAASubproduct>() { // So far, only received GOES 13 images. Coecidence?
                 { (int) ScannerSubProduct.NONE,                         new NOAASubproduct(ScannerSubProduct.NONE,                          "None") },
                 { (int) ScannerSubProduct.INFRARED_FULLDISK,            new NOAASubproduct(ScannerSubProduct.INFRARED_FULLDISK,             "Infrared Full Disk") },
                 { (int) ScannerSubProduct.INFRARED_NORTHERN,            new NOAASubproduct(ScannerSubProduct.INFRARED_NORTHERN,             "Infrared Northern Hemisphere") },
@@ -50,7 +50,7 @@ namespace OpenSatelliteProject.PacketData {
                 { (int) ScannerSubProduct.WATERVAPOUR_AREA_OF_INTEREST, new NOAASubproduct(ScannerSubProduct.WATERVAPOUR_AREA_OF_INTEREST,  "Water Vapour Area of Interest") }
             }));
 
-            noaaProducts.Add((int)NOAAProductID.SCANNER_DATA_2, new NOAAProduct(NOAAProductID.SCANNER_DATA_2, "Scanner Image", new Dictionary<int, NOAASubproduct>() { // So far, only received GOES 15 images. Coecidence? 
+            noaaProducts.Add((int)NOAAProductID.GOES15_ABI, new NOAAProduct(NOAAProductID.GOES15_ABI, "GOES 15 ABI", new Dictionary<int, NOAASubproduct>() { // So far, only received GOES 15 images. Coecidence? 
                 { (int) ScannerSubProduct.NONE,                         new NOAASubproduct(ScannerSubProduct.NONE,                          "None") },
                 { (int) ScannerSubProduct.INFRARED_FULLDISK,            new NOAASubproduct(ScannerSubProduct.INFRARED_FULLDISK,             "Infrared Full Disk") },
                 { (int) ScannerSubProduct.INFRARED_NORTHERN,            new NOAASubproduct(ScannerSubProduct.INFRARED_NORTHERN,             "Infrared Northern Hemisphere") },
@@ -69,7 +69,7 @@ namespace OpenSatelliteProject.PacketData {
                 { (int) ScannerSubProduct.WATERVAPOUR_AREA_OF_INTEREST, new NOAASubproduct(ScannerSubProduct.WATERVAPOUR_AREA_OF_INTEREST,  "Water Vapour Area of Interest") }
             }));
 
-            noaaProducts.Add((int)NOAAProductID.SCANNER_DATA_3, new NOAAProduct(NOAAProductID.SCANNER_DATA_3, "GOES 16 ABI", new Dictionary<int, NOAASubproduct>() {
+            noaaProducts.Add((int)NOAAProductID.GOES16_ABI, new NOAAProduct(NOAAProductID.GOES16_ABI, "GOES 16 ABI", new Dictionary<int, NOAASubproduct>() {
                 { (int) ScannerSubProduct.NONE,                         new NOAASubproduct(ScannerSubProduct.NONE,                          "None") },
                 {                            1,                         new NOAASubproduct(                     1,                          "Channel 1") },
                 {                            2,                         new NOAASubproduct(                     2,                          "Channel 2") },
@@ -89,8 +89,25 @@ namespace OpenSatelliteProject.PacketData {
                 {                           16,                         new NOAASubproduct(                    16,                          "Channel 16") }
             }));
 
-
-
+            noaaProducts.Add((int)NOAAProductID.HIMAWARI8_ABI, new NOAAProduct(NOAAProductID.HIMAWARI8_ABI, "HIMAWARI8 ABI", new Dictionary<int, NOAASubproduct>() {
+                { (int) ScannerSubProduct.NONE,                         new NOAASubproduct(ScannerSubProduct.NONE,                          "None") },
+                {                            1,                         new NOAASubproduct(                     1,                          "Channel 1") },
+                {                            2,                         new NOAASubproduct(                     2,                          "Channel 2") },
+                {                            3,                         new NOAASubproduct(                     3,                          "Channel 3") },
+                {                            4,                         new NOAASubproduct(                     4,                          "Channel 4") },
+                {                            5,                         new NOAASubproduct(                     5,                          "Channel 5") },
+                {                            6,                         new NOAASubproduct(                     6,                          "Channel 6") },
+                {                            7,                         new NOAASubproduct(                     7,                          "Channel 7") },
+                {                            8,                         new NOAASubproduct(                     8,                          "Channel 8") },
+                {                            9,                         new NOAASubproduct(                     9,                          "Channel 9") },
+                {                           10,                         new NOAASubproduct(                    10,                          "Channel 10") },
+                {                           11,                         new NOAASubproduct(                    11,                          "Channel 11") },
+                {                           12,                         new NOAASubproduct(                    12,                          "Channel 12") },
+                {                           13,                         new NOAASubproduct(                    13,                          "Channel 13") },
+                {                           14,                         new NOAASubproduct(                    14,                          "Channel 14") },
+                {                           15,                         new NOAASubproduct(                    15,                          "Channel 15") },
+                {                           16,                         new NOAASubproduct(                    16,                          "Channel 16") }
+            }));
 
             noaaProducts.Add((int)NOAAProductID.EMWIN, new NOAAProduct(NOAAProductID.EMWIN, "EMWIN"));
         }

--- a/XRIT/Tools/LLTools.cs
+++ b/XRIT/Tools/LLTools.cs
@@ -31,6 +31,10 @@ namespace OpenSatelliteProject.Tools {
             return dtDateTime;
         }
 
+        public static int Timestamp() {
+            return (Int32)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
+        }
+
         public static List<T> Clone<T>(this List<T> listToClone) where T: ICloneable {
             return listToClone.Select(item => (T)item.Clone()).ToList();
         }

--- a/XRIT/Tools/Organizer.cs
+++ b/XRIT/Tools/Organizer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Collections.Generic;
 using OpenSatelliteProject.Tools;
 using System.Globalization;
+using OpenSatelliteProject.PacketData.Enums;
 
 namespace OpenSatelliteProject {
     public class Organizer {
@@ -30,49 +31,54 @@ namespace OpenSatelliteProject {
                 }
                 try {
                     var header = FileParser.GetHeaderFromFile(file);
-                    var anciliary = header.AncillaryHeader.Values;
+                    var anciliary = header.AncillaryHeader != null ? header.AncillaryHeader.Values : null;
                     var satellite = "Unknown";
                     var region = "Unknown";
                     var datetime = header.TimestampHeader.DateTime; // Defaults to capture time
                     var channel = 99;
                     var segmentId = header.SegmentIdentificationHeader != null ? header.SegmentIdentificationHeader.Sequence : 0;
 
-                    if (anciliary.ContainsKey("Satellite")) {
-                        satellite = anciliary["Satellite"];
+                    if (header.Product.ID == (int)NOAAProductID.HIMAWARI8_ABI) {
+                        channel = header.SubProduct.ID;
+                        satellite = "HIMAWARI8";
+                        region = "Full Disk";
                     }
 
-                    if (anciliary.ContainsKey("Region")) {
-                        region = anciliary["Region"];
-                    }
-
-                    if (anciliary.ContainsKey("Channel")) {
-                        channel = int.Parse(anciliary["Channel"]);
-                    }
-
-                    if (anciliary.ContainsKey("Time of frame start")) {
-                        var dtstring = anciliary["Time of frame start"];
-                        // 2017/055/05:45:18
-                        // or
-                        // 2017-03-27T15:45:38.2Z
-                        if (dtstring[4] == '/') {
-                            var year = dtstring.Substring(0, 4);
-                            var dayOfYear = dtstring.Substring(5, 3);
-                            var hours = dtstring.Substring(9, 2);
-                            var minutes = dtstring.Substring(12, 2);
-                            var seconds = dtstring.Substring(15, 2);
-                            //Console.WriteLine("Year: {0}\nDay Of Year: {1}\nHours: {2}\nMinutes: {3}\nSeconds: {4}", year, dayOfYear, hours, minutes, seconds);
-                            datetime = new DateTime(int.Parse(year), 1, 1, int.Parse(hours), int.Parse(minutes), int.Parse(seconds));
-                            datetime = datetime.AddDays(int.Parse(dayOfYear));
-                        } else {
-                            datetime = DateTime.Parse(dtstring, null, DateTimeStyles.RoundtripKind);
+                    if (anciliary != null) {
+                        if (anciliary.ContainsKey("Satellite")) {
+                            satellite = anciliary["Satellite"];
                         }
-                    } else {
-                        Console.WriteLine("No Frame Time of Start found! Using capture time.");
+
+                        if (anciliary.ContainsKey("Region")) {
+                            region = anciliary["Region"];
+                        }
+
+                        if (anciliary.ContainsKey("Channel")) {
+                            channel = int.Parse(anciliary["Channel"]);
+                        } 
+
+
+                        if (anciliary.ContainsKey("Time of frame start")) {
+                            var dtstring = anciliary["Time of frame start"];
+                            // 2017/055/05:45:18
+                            // or
+                            // 2017-03-27T15:45:38.2Z
+                            if (dtstring[4] == '/') {
+                                var year = dtstring.Substring(0, 4);
+                                var dayOfYear = dtstring.Substring(5, 3);
+                                var hours = dtstring.Substring(9, 2);
+                                var minutes = dtstring.Substring(12, 2);
+                                var seconds = dtstring.Substring(15, 2);
+                                //Console.WriteLine("Year: {0}\nDay Of Year: {1}\nHours: {2}\nMinutes: {3}\nSeconds: {4}", year, dayOfYear, hours, minutes, seconds);
+                                datetime = new DateTime(int.Parse(year), 1, 1, int.Parse(hours), int.Parse(minutes), int.Parse(seconds));
+                                datetime = datetime.AddDays(int.Parse(dayOfYear));
+                            } else {
+                                datetime = DateTime.Parse(dtstring, null, DateTimeStyles.RoundtripKind);
+                            }
+                        } else {
+                            Console.WriteLine("No Frame Time of Start found! Using capture time.");
+                        }
                     }
-                    /*
-                    foreach(var x in header.AncillaryHeader.Values) {
-                        Console.WriteLine("{0}: {1}", x.Key, x.Value);
-                    }*/
 
                     var timestamp = (int)Math.Floor((datetime - UnixEpoch).TotalSeconds);
 
@@ -97,23 +103,28 @@ namespace OpenSatelliteProject {
                             }
                             break;
                         case 3: // Water Vapour
-                            od = grp.WaterVapour;
+                            if (satellite == "HIMAWARI8") {
+                                od = grp.Infrared;
+                            } else {
+                                od = grp.WaterVapour;
+                            }
                             break;
                         case 4: // Infrared
                             od = grp.Infrared;
                             break;
+                        case 7: 
+                            if (satellite == "HIMAWARI8") {
+                                od = grp.WaterVapour;
+                            }
+                            break;
                         case 8:
                             if (satellite == "G16") {
                                 od = grp.WaterVapour;
-                            } else {
-                                //Console.WriteLine("Unknown Channel {0}", channel);
                             }
                             break;
                         case 13: // Infrared for G16
                             if (satellite == "G16") {
                                 od = grp.Infrared;
-                            } else {
-                                //Console.WriteLine("Unknown Channel {0}", channel);
                             }
                             break;
                         default:

--- a/XRIT/Tools/Organizer.cs
+++ b/XRIT/Tools/Organizer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using OpenSatelliteProject.Tools;
+using System.Globalization;
 
 namespace OpenSatelliteProject {
     public class Organizer {
@@ -34,7 +35,7 @@ namespace OpenSatelliteProject {
                     var region = "Unknown";
                     var datetime = header.TimestampHeader.DateTime; // Defaults to capture time
                     var channel = 99;
-                    var segmentId = header.SegmentIdentificationHeader.Sequence;
+                    var segmentId = header.SegmentIdentificationHeader != null ? header.SegmentIdentificationHeader.Sequence : 0;
 
                     if (anciliary.ContainsKey("Satellite")) {
                         satellite = anciliary["Satellite"];
@@ -50,15 +51,21 @@ namespace OpenSatelliteProject {
 
                     if (anciliary.ContainsKey("Time of frame start")) {
                         var dtstring = anciliary["Time of frame start"];
-                        //2017/055/05:45:18
-                        var year = dtstring.Substring(0, 4);
-                        var dayOfYear = dtstring.Substring(5, 3);
-                        var hours = dtstring.Substring(9, 2);
-                        var minutes = dtstring.Substring(12, 2);
-                        var seconds = dtstring.Substring(15, 2);
-                        //Console.WriteLine("Year: {0}\nDay Of Year: {1}\nHours: {2}\nMinutes: {3}\nSeconds: {4}", year, dayOfYear, hours, minutes, seconds);
-                        datetime = new DateTime(int.Parse(year), 1, 1, int.Parse(hours), int.Parse(minutes), int.Parse(seconds));
-                        datetime = datetime.AddDays(int.Parse(dayOfYear));
+                        // 2017/055/05:45:18
+                        // or
+                        // 2017-03-27T15:45:38.2Z
+                        if (dtstring[4] == '/') {
+                            var year = dtstring.Substring(0, 4);
+                            var dayOfYear = dtstring.Substring(5, 3);
+                            var hours = dtstring.Substring(9, 2);
+                            var minutes = dtstring.Substring(12, 2);
+                            var seconds = dtstring.Substring(15, 2);
+                            //Console.WriteLine("Year: {0}\nDay Of Year: {1}\nHours: {2}\nMinutes: {3}\nSeconds: {4}", year, dayOfYear, hours, minutes, seconds);
+                            datetime = new DateTime(int.Parse(year), 1, 1, int.Parse(hours), int.Parse(minutes), int.Parse(seconds));
+                            datetime = datetime.AddDays(int.Parse(dayOfYear));
+                        } else {
+                            datetime = DateTime.Parse(dtstring, null, DateTimeStyles.RoundtripKind);
+                        }
                     } else {
                         Console.WriteLine("No Frame Time of Start found! Using capture time.");
                     }
@@ -82,11 +89,32 @@ namespace OpenSatelliteProject {
                         case 1: // Visible
                             od = grp.Visible;
                             break;
+                        case 2: // Visible for G16
+                            if (satellite == "G16") {
+                                od = grp.Visible;
+                            } else {
+                                Console.WriteLine("Unknown Channel {0}", channel);
+                            }
+                            break;
                         case 3: // Water Vapour
                             od = grp.WaterVapour;
                             break;
                         case 4: // Infrared
                             od = grp.Infrared;
+                            break;
+                        case 8:
+                            if (satellite == "G16") {
+                                od = grp.WaterVapour;
+                            } else {
+                                Console.WriteLine("Unknown Channel {0}", channel);
+                            }
+                            break;
+                        case 13: // Infrared for G16
+                            if (satellite == "G16") {
+                                od = grp.Infrared;
+                            } else {
+                                Console.WriteLine("Unknown Channel {0}", channel);
+                            }
                             break;
                         default:
                             Console.WriteLine("Unknown Channel {0}", channel);
@@ -100,7 +128,11 @@ namespace OpenSatelliteProject {
                         od.Lines = header.ImageStructureHeader.Lines;
                         od.PixelAspect = header.ImageNavigationHeader.ColumnScalingFactor / (float)header.ImageNavigationHeader.LineScalingFactor;
                         od.StartColumn = header.ImageNavigationHeader.ColumnOffset;
-                        od.MaxSegments = header.SegmentIdentificationHeader.MaxSegments;
+                        if (header.SegmentIdentificationHeader != null) {
+                            od.MaxSegments = header.SegmentIdentificationHeader.MaxSegments;
+                        } else {
+                            od.MaxSegments = 1;
+                        }
                     } else {
                         od.Lines += header.ImageStructureHeader.Lines;
                     }

--- a/XRIT/Tools/Organizer.cs
+++ b/XRIT/Tools/Organizer.cs
@@ -106,18 +106,18 @@ namespace OpenSatelliteProject {
                             if (satellite == "G16") {
                                 od = grp.WaterVapour;
                             } else {
-                                Console.WriteLine("Unknown Channel {0}", channel);
+                                //Console.WriteLine("Unknown Channel {0}", channel);
                             }
                             break;
                         case 13: // Infrared for G16
                             if (satellite == "G16") {
                                 od = grp.Infrared;
                             } else {
-                                Console.WriteLine("Unknown Channel {0}", channel);
+                                //Console.WriteLine("Unknown Channel {0}", channel);
                             }
                             break;
                         default:
-                            Console.WriteLine("Unknown Channel {0}", channel);
+                            //Console.WriteLine("Unknown Channel {0}", channel);
                             continue;
                     } 
 

--- a/XRIT/XRIT.csproj
+++ b/XRIT/XRIT.csproj
@@ -104,6 +104,8 @@
     <Compile Include="Log\SyslogClient.cs" />
     <Compile Include="PacketData\EMWINHeader.cs" />
     <Compile Include="PacketData\EmwinFile.cs" />
+    <Compile Include="DCS\DCSHeader.cs" />
+    <Compile Include="DCS\DCSParser.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -111,5 +113,6 @@
     <Folder Include="Tools\" />
     <Folder Include="Models\" />
     <Folder Include="Log\" />
+    <Folder Include="DCS\" />
   </ItemGroup>
 </Project>

--- a/XRIT/XRIT.csproj
+++ b/XRIT/XRIT.csproj
@@ -102,6 +102,8 @@
     <Compile Include="Log\Facility.cs" />
     <Compile Include="Log\Message.cs" />
     <Compile Include="Log\SyslogClient.cs" />
+    <Compile Include="PacketData\EMWINHeader.cs" />
+    <Compile Include="PacketData\EmwinFile.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/XRITLibraryTest/MainWindow.cs
+++ b/XRITLibraryTest/MainWindow.cs
@@ -19,9 +19,9 @@ public partial class MainWindow: Gtk.Window {
             ProcessFile(fileChooser.Filename);
         };
 
-        string debugFrames = "/media/ELTN/tmp/demuxdump-1490627438.bin";
+        //string debugFrames = "/media/ELTN/tmp/demuxdump-1490627438.bin";
         //string debugFrames = "/home/lucas/Works/OpenSatelliteProject/split/issues/trango/3/debug_frames.bin";
-        //string debugFrames = "/media/ELTN/tmp/debug2/debug_frames.bin";
+        string debugFrames = "/media/ELTN/tmp/debug3/raw_data.bin";
         dm = new DemuxManager();
         FileHandler.SkipDCS = true;
         FileHandler.SkipEMWIN = true;

--- a/XRITLibraryTest/MainWindow.cs
+++ b/XRITLibraryTest/MainWindow.cs
@@ -19,11 +19,13 @@ public partial class MainWindow: Gtk.Window {
             ProcessFile(fileChooser.Filename);
         };
 
-        string debugFrames = "/home/lucas/Works/OpenSatelliteProject/split/issues/trango/3/debug_frames.bin";
+        //string debugFrames = "/home/lucas/Works/OpenSatelliteProject/split/issues/trango/3/debug_frames.bin";
+        string debugFrames = "/media/ELTN/tmp/demuxdump-1490627438.bin";
         dm = new DemuxManager();
-        //FileHandler.SkipDCS = true;
+        FileHandler.SkipDCS = true;
         FileHandler.SkipEMWIN = true;
-        int startFrame = 83000;
+        //int startFrame = 83000;
+        int startFrame = 0;
         FileStream file = File.OpenRead(debugFrames);
         byte[] data = new byte[892];
         long bytesRead = startFrame * 892;
@@ -31,7 +33,7 @@ public partial class MainWindow: Gtk.Window {
         int frameN = startFrame;
         file.Position = bytesRead;
         while (bytesRead < bytesToRead) {
-            Console.WriteLine("Injecting Frame {0}", frameN);
+            //Console.WriteLine("Injecting Frame {0}", frameN);
             bytesRead += file.Read(data, 0, 892);
             dm.parseBytes(data);
             frameN++;

--- a/XRITLibraryTest/MainWindow.cs
+++ b/XRITLibraryTest/MainWindow.cs
@@ -28,8 +28,8 @@ public partial class MainWindow: Gtk.Window {
         ImageManager.GenerateFalseColor = true;
         im.Start();
         dm = new DemuxManager();
-        FileHandler.SkipDCS = true;
-        FileHandler.SkipEMWIN = true;
+        //FileHandler.SkipDCS = true;
+        //FileHandler.SkipEMWIN = true;
         //int startFrame = 83000;
         int startFrame = 0;
         FileStream file = File.OpenRead(debugFrames);

--- a/XRITLibraryTest/MainWindow.cs
+++ b/XRITLibraryTest/MainWindow.cs
@@ -19,9 +19,9 @@ public partial class MainWindow: Gtk.Window {
             ProcessFile(fileChooser.Filename);
         };
 
-        //string debugFrames = "/media/ELTN/tmp/demuxdump-1490627438.bin";
+        string debugFrames = "/media/ELTN/tmp/demuxdump-1490627438.bin";
         //string debugFrames = "/home/lucas/Works/OpenSatelliteProject/split/issues/trango/3/debug_frames.bin";
-        string debugFrames = "/media/ELTN/tmp/debug3/raw_data.bin";
+        //string debugFrames = "/media/ELTN/tmp/debug3/raw_data.bin";
         var im = new ImageManager("channels/Images/FM1");
         ImageManager.GenerateVisible = true;
         ImageManager.GenerateInfrared = true;

--- a/XRITLibraryTest/MainWindow.cs
+++ b/XRITLibraryTest/MainWindow.cs
@@ -19,17 +19,17 @@ public partial class MainWindow: Gtk.Window {
             ProcessFile(fileChooser.Filename);
         };
 
-        string debugFrames = "/media/ELTN/tmp/demuxdump-1490627438.bin";
-        //string debugFrames = "/home/lucas/Works/OpenSatelliteProject/split/issues/trango/3/debug_frames.bin";
+        //string debugFrames = "/media/ELTN/tmp/demuxdump-1490627438.bin";
+        string debugFrames = "/home/lucas/Works/OpenSatelliteProject/split/issues/trango/3/debug_frames.bin";
         //string debugFrames = "/media/ELTN/tmp/debug3/raw_data.bin";
-        var im = new ImageManager("channels/Images/FM1");
+        var im = new ImageManager("channels/Images/Full Disk/");
         ImageManager.GenerateVisible = true;
         ImageManager.GenerateInfrared = true;
         ImageManager.GenerateFalseColor = true;
         im.Start();
         dm = new DemuxManager();
-        //FileHandler.SkipDCS = true;
-        //FileHandler.SkipEMWIN = true;
+        FileHandler.SkipDCS = true;
+        FileHandler.SkipEMWIN = true;
         //int startFrame = 83000;
         int startFrame = 0;
         FileStream file = File.OpenRead(debugFrames);

--- a/XRITLibraryTest/MainWindow.cs
+++ b/XRITLibraryTest/MainWindow.cs
@@ -22,6 +22,11 @@ public partial class MainWindow: Gtk.Window {
         //string debugFrames = "/media/ELTN/tmp/demuxdump-1490627438.bin";
         //string debugFrames = "/home/lucas/Works/OpenSatelliteProject/split/issues/trango/3/debug_frames.bin";
         string debugFrames = "/media/ELTN/tmp/debug3/raw_data.bin";
+        var im = new ImageManager("channels/Images/FM1");
+        ImageManager.GenerateVisible = true;
+        ImageManager.GenerateInfrared = true;
+        ImageManager.GenerateFalseColor = true;
+        im.Start();
         dm = new DemuxManager();
         FileHandler.SkipDCS = true;
         FileHandler.SkipEMWIN = true;
@@ -45,6 +50,7 @@ public partial class MainWindow: Gtk.Window {
         Console.WriteLine("Frame Loss: {0}", dm.FrameLoss);
         Console.WriteLine("Length Fails: {0}", dm.LengthFails);
         Console.WriteLine("Packets: {0}", dm.Packets);
+        im.Stop();
 
         //ProcessFile("/home/lucas/Works/OpenSatelliteProject/split/goesdump/goesdump/bin/Debug/channels/Text/NWSTEXTdat043204159214.lrit");
         /*

--- a/XRITLibraryTest/MainWindow.cs
+++ b/XRITLibraryTest/MainWindow.cs
@@ -19,8 +19,9 @@ public partial class MainWindow: Gtk.Window {
             ProcessFile(fileChooser.Filename);
         };
 
-        //string debugFrames = "/home/lucas/Works/OpenSatelliteProject/split/issues/trango/3/debug_frames.bin";
         string debugFrames = "/media/ELTN/tmp/demuxdump-1490627438.bin";
+        //string debugFrames = "/home/lucas/Works/OpenSatelliteProject/split/issues/trango/3/debug_frames.bin";
+        //string debugFrames = "/media/ELTN/tmp/debug2/debug_frames.bin";
         dm = new DemuxManager();
         FileHandler.SkipDCS = true;
         FileHandler.SkipEMWIN = true;

--- a/XRITLibraryTest/MainWindow.cs
+++ b/XRITLibraryTest/MainWindow.cs
@@ -6,6 +6,8 @@ using OpenSatelliteProject.Tools;
 using System.Drawing;
 using System.Drawing.Imaging;
 using OpenSatelliteProject.Log;
+using OpenSatelliteProject.DCS;
+using System.Collections.Generic;
 
 public partial class MainWindow: Gtk.Window {
 
@@ -19,6 +21,9 @@ public partial class MainWindow: Gtk.Window {
             ProcessFile(fileChooser.Filename);
         };
 
+        string dcsFile = "/home/lucas/Works/OpenSatelliteProject/split/goesdump/XRITLibraryTest/bin/Debug/channels/DCS/pM-17085003239-A.dcs";
+        List<DCSHeader> d = DCSParser.parseDCS(dcsFile);
+        /*
         //string debugFrames = "/media/ELTN/tmp/demuxdump-1490627438.bin";
         string debugFrames = "/home/lucas/Works/OpenSatelliteProject/split/issues/trango/3/debug_frames.bin";
         //string debugFrames = "/media/ELTN/tmp/debug3/raw_data.bin";
@@ -51,7 +56,7 @@ public partial class MainWindow: Gtk.Window {
         Console.WriteLine("Length Fails: {0}", dm.LengthFails);
         Console.WriteLine("Packets: {0}", dm.Packets);
         im.Stop();
-
+        */
         //ProcessFile("/home/lucas/Works/OpenSatelliteProject/split/goesdump/goesdump/bin/Debug/channels/Text/NWSTEXTdat043204159214.lrit");
         /*
         Organizer organizer = new Organizer("/home/lucas/Works/OpenSatelliteProject/split/goesdump/goesdump/bin/Debug/channels/Images/Full Disk");

--- a/XRITLibraryTest/XRITLibraryTest.csproj
+++ b/XRITLibraryTest/XRITLibraryTest.csproj
@@ -78,6 +78,9 @@
     </Reference>
     <Reference Include="Mono.Posix" />
     <Reference Include="System.Drawing" />
+    <Reference Include="ICSharpCode.SharpZipLib">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="gtk-gui\gui.stetic">
@@ -101,5 +104,8 @@
       <Project>{E1B44542-24FF-409C-A2A3-237A00A8520D}</Project>
       <Name>GOES Dumper</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/XRITLibraryTest/packages.config
+++ b/XRITLibraryTest/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+</packages>

--- a/goesdump.userprefs
+++ b/goesdump.userprefs
@@ -1,21 +1,18 @@
-﻿<Properties StartupItem="goesdump/GOES Dumper.csproj" RefactoringSettings.EnableRefactorings="True">
+﻿<Properties StartupItem="XRITLibraryTest/XRITLibraryTest.csproj" RefactoringSettings.EnableRefactorings="True">
   <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug Headless|x86" />
-  <MonoDevelop.Ide.Workbench ActiveDocument="goesdump/ChannelDecoder/Demuxer.cs">
+  <MonoDevelop.Ide.Workbench ActiveDocument="goesdump/ChannelDecoder/DemuxManager.cs">
     <Files>
       <File FileName="goesdump/UIComponents/UIConsole.cs" Line="1" Column="1" />
-      <File FileName="goesdump/HeadlessMain.cs" Line="1" Column="1" />
+      <File FileName="goesdump/HeadlessMain.cs" Line="133" Column="46" />
       <File FileName="XRITLibraryTest/MainWindow.cs" Line="24" Column="11" />
-      <File FileName="goesdump/ChannelDecoder/Demuxer.cs" Line="240" Column="1" />
       <File FileName="goesdump/GoesDecoder/FileHandler.cs" Line="1" Column="1" />
-      <File FileName="goesdump/ChannelDecoder/DemuxManager.cs" Line="28" Column="44" />
-      <File FileName="XRIT/PacketData/MSDU.cs" Line="77" Column="1" />
+      <File FileName="goesdump/ChannelDecoder/DemuxManager.cs" Line="52" Column="59" />
+      <File FileName="XRIT/PacketData/MSDU.cs" Line="57" Column="9" />
+      <File FileName="XRIT/Tools/LLTools.cs" Line="35" Column="20" />
     </Files>
   </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
-    <BreakpointStore>
-      <Breakpoint file="/home/lucas/Works/OpenSatelliteProject/split/goesdump/goesdump/ChannelDecoder/Demuxer.cs" line="175" column="1" />
-      <Breakpoint file="/home/lucas/Works/OpenSatelliteProject/split/goesdump/XRIT/PacketData/MSDU.cs" line="77" column="23" />
-    </BreakpointStore>
+    <BreakpointStore />
   </MonoDevelop.Ide.DebuggingService.Breakpoints>
   <MonoDevelop.Ide.DebuggingService.PinnedWatches>
     <Watch file="XRIT/Tools/AEC.cs" line="32" offsetX="528" offsetY="496" expression="param" liveUpdate="False" />

--- a/goesdump.userprefs
+++ b/goesdump.userprefs
@@ -1,31 +1,30 @@
 ﻿<Properties StartupItem="XRITLibraryTest/XRITLibraryTest.csproj" RefactoringSettings.EnableRefactorings="True">
   <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug Headless|x86" />
-  <MonoDevelop.Ide.Workbench ActiveDocument="XRIT/Tools/ImageHandler.cs">
+  <MonoDevelop.Ide.Workbench ActiveDocument="XRIT/PacketData/MSDU.cs">
     <Files>
       <File FileName="goesdump/UIComponents/UIConsole.cs" Line="1" Column="1" />
       <File FileName="goesdump/HeadlessMain.cs" Line="1" Column="1" />
-      <File FileName="XRITLibraryTest/MainWindow.cs" Line="1" Column="1" />
-      <File FileName="goesdump/GoesDecoder/FileHandler.cs" Line="1" Column="1" />
-      <File FileName="goesdump/ChannelDecoder/DemuxManager.cs" Line="1" Column="1" />
-      <File FileName="XRIT/PacketData/MSDU.cs" Line="1" Column="1" />
-      <File FileName="XRIT/Tools/LLTools.cs" Line="1" Column="1" />
-      <File FileName="XRIT/Tools/AEC.cs" Line="1" Column="1" />
-      <File FileName="goesdump/GoesDecoder/PacketManager.cs" Line="1" Column="1" />
-      <File FileName="goesdump/ChannelDecoder/Demuxer.cs" Line="1" Column="1" />
-      <File FileName="XRIT/PacketData/RiceCompressionHeader.cs" Line="1" Column="1" />
-      <File FileName="XRIT/PacketData/Enums/CompressionType.cs" Line="9" Column="17" />
-      <File FileName="XRIT/Tools/ImageTools.cs" Line="1" Column="1" />
-      <File FileName="XRIT/Tools/ImageHandler.cs" Line="46" Column="17" />
+      <File FileName="goesdump/GoesDecoder/PacketManager.cs" Line="428" Column="18" />
+      <File FileName="goesdump/ChannelDecoder/Demuxer.cs" Line="201" Column="36" />
+      <File FileName="XRITLibraryTest/MainWindow.cs" Line="22" Column="71" />
+      <File FileName="goesdump/ChannelDecoder/DemuxManager.cs" Line="49" Column="34" />
+      <File FileName="XRIT/PacketData/MSDU.cs" Line="87" Column="13" />
     </Files>
+    <Pads>
+      <Pad Id="MonoDevelop.Debugger.WatchPad">
+        <State>
+          <Value>temporaryStorage[lastAPID]</Value>
+        </State>
+      </Pad>
+    </Pads>
   </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
-    <BreakpointStore>
-      <Breakpoint file="/home/lucas/Works/OpenSatelliteProject/split/goesdump/goesdump/GoesDecoder/PacketManager.cs" line="308" column="1" />
-    </BreakpointStore>
+    <BreakpointStore />
   </MonoDevelop.Ide.DebuggingService.Breakpoints>
   <MonoDevelop.Ide.DebuggingService.PinnedWatches>
     <Watch file="XRIT/Tools/AEC.cs" line="32" offsetX="528" offsetY="496" expression="param" liveUpdate="False" />
     <Watch file="XRIT/Tools/ImageTools.cs" line="56" offsetX="608" offsetY="880" expression="filename" liveUpdate="False" />
+    <Watch file="goesdump/GoesDecoder/FileHandler.cs" line="81" offsetX="360" offsetY="1280" expression="e" liveUpdate="False" />
   </MonoDevelop.Ide.DebuggingService.PinnedWatches>
   <AuthorInfo Name="Lucas Teske" Email="lucas@teske.com.br" Copyright="OpenSatelliteProject @ 2016" Company="OpenSatelliteProject" Trademark="" />
 </Properties>

--- a/goesdump.userprefs
+++ b/goesdump.userprefs
@@ -1,18 +1,27 @@
 ﻿<Properties StartupItem="XRITLibraryTest/XRITLibraryTest.csproj" RefactoringSettings.EnableRefactorings="True">
   <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug Headless|x86" />
-  <MonoDevelop.Ide.Workbench ActiveDocument="goesdump/ChannelDecoder/DemuxManager.cs">
+  <MonoDevelop.Ide.Workbench ActiveDocument="XRIT/Tools/ImageHandler.cs">
     <Files>
       <File FileName="goesdump/UIComponents/UIConsole.cs" Line="1" Column="1" />
-      <File FileName="goesdump/HeadlessMain.cs" Line="133" Column="46" />
-      <File FileName="XRITLibraryTest/MainWindow.cs" Line="24" Column="11" />
+      <File FileName="goesdump/HeadlessMain.cs" Line="1" Column="1" />
+      <File FileName="XRITLibraryTest/MainWindow.cs" Line="1" Column="1" />
       <File FileName="goesdump/GoesDecoder/FileHandler.cs" Line="1" Column="1" />
-      <File FileName="goesdump/ChannelDecoder/DemuxManager.cs" Line="52" Column="59" />
-      <File FileName="XRIT/PacketData/MSDU.cs" Line="57" Column="9" />
-      <File FileName="XRIT/Tools/LLTools.cs" Line="35" Column="20" />
+      <File FileName="goesdump/ChannelDecoder/DemuxManager.cs" Line="1" Column="1" />
+      <File FileName="XRIT/PacketData/MSDU.cs" Line="1" Column="1" />
+      <File FileName="XRIT/Tools/LLTools.cs" Line="1" Column="1" />
+      <File FileName="XRIT/Tools/AEC.cs" Line="1" Column="1" />
+      <File FileName="goesdump/GoesDecoder/PacketManager.cs" Line="1" Column="1" />
+      <File FileName="goesdump/ChannelDecoder/Demuxer.cs" Line="1" Column="1" />
+      <File FileName="XRIT/PacketData/RiceCompressionHeader.cs" Line="1" Column="1" />
+      <File FileName="XRIT/PacketData/Enums/CompressionType.cs" Line="9" Column="17" />
+      <File FileName="XRIT/Tools/ImageTools.cs" Line="1" Column="1" />
+      <File FileName="XRIT/Tools/ImageHandler.cs" Line="46" Column="17" />
     </Files>
   </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
-    <BreakpointStore />
+    <BreakpointStore>
+      <Breakpoint file="/home/lucas/Works/OpenSatelliteProject/split/goesdump/goesdump/GoesDecoder/PacketManager.cs" line="308" column="1" />
+    </BreakpointStore>
   </MonoDevelop.Ide.DebuggingService.Breakpoints>
   <MonoDevelop.Ide.DebuggingService.PinnedWatches>
     <Watch file="XRIT/Tools/AEC.cs" line="32" offsetX="528" offsetY="496" expression="param" liveUpdate="False" />

--- a/goesdump.userprefs
+++ b/goesdump.userprefs
@@ -1,4 +1,4 @@
-﻿<Properties StartupItem="XRITLibraryTest/XRITLibraryTest.csproj" RefactoringSettings.EnableRefactorings="True">
+﻿<Properties StartupItem="goesdump/GOES Dumper.csproj" RefactoringSettings.EnableRefactorings="True">
   <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug Headless|x86" />
   <MonoDevelop.Ide.Workbench ActiveDocument="XRIT/PacketData/MSDU.cs">
     <Files>

--- a/goesdump.userprefs
+++ b/goesdump.userprefs
@@ -1,4 +1,4 @@
-﻿<Properties StartupItem="XRITLibraryTest/XRITLibraryTest.csproj" RefactoringSettings.EnableRefactorings="True">
+﻿<Properties StartupItem="goesdump/GOES Dumper.csproj" RefactoringSettings.EnableRefactorings="True">
   <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug Headless|x86" />
   <MonoDevelop.Ide.Workbench ActiveDocument="goesdump/ChannelDecoder/Demuxer.cs">
     <Files>

--- a/goesdump/ChannelDecoder/Demuxer.cs
+++ b/goesdump/ChannelDecoder/Demuxer.cs
@@ -137,6 +137,17 @@ namespace OpenSatelliteProject {
                     return;
                 }
 
+                // LRIT EMWIN
+                /* Uncomment to enable EMWIN Ingestor 
+                 * Its broken right now
+                if (fileHeader.PrimaryHeader.FileType == FileTypeCode.EMWIN) {
+                    //Ingestor
+                    int offset = 10 + (int)fileHeader.PrimaryHeader.HeaderLength;
+                    EMWIN.Ingestor.Process(msdu.Data.Skip(offset).ToArray());
+                    return;
+                }
+                */
+
                 string path = String.Format("channels/{0}", channelId);
                 if (!Directory.Exists(path)) {
                     Directory.CreateDirectory(path);

--- a/goesdump/ChannelDecoder/Demuxer.cs
+++ b/goesdump/ChannelDecoder/Demuxer.cs
@@ -154,9 +154,9 @@ namespace OpenSatelliteProject {
                     if (fileHeader.Compression == CompressionType.LRIT_RICE) { // # Rice
                         string decompressed;
                         if (msdu.Sequence == SequenceType.SINGLE_DATA) {
-                            decompressed = PacketManager.Decompressor(filename, fileHeader.ImageStructureHeader.Columns);
+                            decompressed = PacketManager.Decompressor(filename, fileHeader.ImageStructureHeader.Columns, fileHeader.RiceCompressionHeader.Pixel, fileHeader.RiceCompressionHeader.Flags);
                         } else {
-                            decompressed = PacketManager.Decompressor(String.Format("channels/{0}/{1}_{2}_", channelId, msdu.APID, msdu.Version), fileHeader.ImageStructureHeader.Columns, startnum, endnum);
+                            decompressed = PacketManager.Decompressor(String.Format("channels/{0}/{1}_{2}_", channelId, msdu.APID, msdu.Version), fileHeader.ImageStructureHeader.Columns, startnum, endnum, fileHeader.RiceCompressionHeader.Pixel, fileHeader.RiceCompressionHeader.Flags);
                         }
 
                         FileHandler.HandleFile(decompressed, fileHeader);

--- a/goesdump/ChannelDecoder/Demuxer.cs
+++ b/goesdump/ChannelDecoder/Demuxer.cs
@@ -191,6 +191,7 @@ namespace OpenSatelliteProject {
         public void ParseBytes(byte[] data) {
             uint counter;
             bool replayFlag;
+            bool ovfVcnt;
 
             if (data.Length < FRAMESIZE) {
                 throw new Exception(String.Format("Not enough data. Expected {0} and got {1}", FRAMESIZE, data.Length));
@@ -222,7 +223,9 @@ namespace OpenSatelliteProject {
                 return;
             }
 
-            if (lastFrame != -1 && lastFrame + 1 != counter) {
+            ovfVcnt = lastFrame == 0xFFFFFF && counter == 0;
+
+            if (lastFrame != -1 && lastFrame + 1 != counter && !ovfVcnt) {
                 UIConsole.GlobalConsole.Error(String.Format("Lost {0} frames. Last Frame #{1} - Current Frame #{2} on VCID {3}", counter - lastFrame - 1, lastFrame, counter, channelId));
                 if (lastAPID != -1) {
                     temporaryStorage[lastAPID].FrameLost = true;

--- a/goesdump/ChannelDecoder/Demuxer.cs
+++ b/goesdump/ChannelDecoder/Demuxer.cs
@@ -106,11 +106,6 @@ namespace OpenSatelliteProject {
                         UIConsole.GlobalConsole.Error(String.Format("Lost some frames on MSDU, the file will be corrupted. CRC Match: {0} - Size Match: {1}", msdu.Valid, msdu.Full));
                     } else {
                         UIConsole.GlobalConsole.Error(String.Format("Corrupted MSDU. CRC Match: {0} - Size Match: {1}", msdu.Valid, msdu.Full));
-                        /*
-                        UIConsole.GlobalConsole.Error("Got a invalid MSDU :(");
-                        UIConsole.GlobalConsole.Debug(String.Format("New Packet for APID {0} - Valid CRC: {1} - Full: {2} - Remaining Bytes: {3} - Frame Lost: {4}", msdu.APID, msdu.Valid, msdu.Full, msdu.RemainingData.Length, msdu.FrameLost));
-                        UIConsole.GlobalConsole.Debug(String.Format("\t\tTotal Size: {0} Current Size: {1}", msdu.PacketLength + 2, msdu.Data.Length)); 
-                        */
                     }
                 }
 
@@ -118,23 +113,13 @@ namespace OpenSatelliteProject {
                     if (startnum != -1) {
                         UIConsole.GlobalConsole.Error("Received First Segment but last data wasn't finished! Forcing dump.");
                         // This can only happen for multi-segment file.
-                        try {
-                            if (fileHeader.Compression == CompressionType.LRIT_RICE) {
-                                string decompressed = PacketManager.Decompressor(String.Format("channels/{0}/{1}_{2}_", channelId, lastMSDU.APID, lastMSDU.Version), fileHeader.ImageStructureHeader.Columns, startnum, endnum, fileHeader.RiceCompressionHeader.Pixel, fileHeader.RiceCompressionHeader.Flags);
-                                FileHandler.HandleFile(decompressed, fileHeader);
-                            } else {
-                                FileHandler.HandleFile(filename, fileHeader);
-                            }
-                        } catch (Exception e) {
-                            UIConsole.GlobalConsole.Error(String.Format("Error handling unfinished file: {0}", e));
-                        }
+                        filename = String.Format("channels/{0}/{1}_{2}.lrit", channelId, lastMSDU.APID, lastMSDU.Version);
+                        FileHandler.HandleFile(filename, fileHeader);
                         startnum = -1;
                         endnum = -1;
                     }
 
                     fileHeader = FileParser.GetHeader(msdu.Data.Skip(10).ToArray());
-                    //compressionFlag = PacketManager.IsCompressed(msdu.Data.Skip(10).ToArray());
-                    //pixels = PacketManager.GetPixels(msdu.Data.Skip(10).ToArray());
 
                     if (msdu.Sequence == SequenceType.FIRST_SEGMENT) {
                         startnum = msdu.PacketNumber;
@@ -143,60 +128,60 @@ namespace OpenSatelliteProject {
                     endnum = msdu.PacketNumber;
 
                     if (startnum == -1) {
-                        //UIConsole.GlobalConsole.Debug("Orphan Packet. Dropping");
+                        // Orphan Packet
                         endnum = -1;
                         return;
                     }
                 } else if (msdu.Sequence != SequenceType.SINGLE_DATA && startnum == -1) {
-                    //UIConsole.GlobalConsole.Debug("Orphan Packet. Dropping");
+                    // Orphan Packet
                     return;
-                } else if (msdu.Sequence == SequenceType.CONTINUED_SEGMENT) {
-                    endnum = msdu.PacketNumber;
                 }
-
-                lastMSDU = msdu;
 
                 string path = String.Format("channels/{0}", channelId);
                 if (!Directory.Exists(path)) {
                     Directory.CreateDirectory(path);
                 }
 
-                switch (fileHeader.Compression) {
-                    case CompressionType.LRIT_RICE: 
-                        filename = String.Format("channels/{0}/{1}_{2}_{3}.lrit", channelId, msdu.APID, msdu.Version, msdu.PacketNumber);
-                        break;
-                    default: // For 0, 2, 5 runs the default
-                        filename = String.Format("channels/{0}/{1}_{2}.lrit", channelId, msdu.APID, msdu.Version);
-                        startnum = -1;
-                        endnum = -1;
-                        break;
+                filename = String.Format("channels/{0}/{1}_{2}.lrit", channelId, msdu.APID, msdu.Version);
+
+                byte[] dataToSave = msdu.Data.Skip(firstOrSinglePacket ? 10 : 0).Take(firstOrSinglePacket ? msdu.PacketLength - 10 : msdu.PacketLength).ToArray(); 
+
+                if (fileHeader.Compression == CompressionType.LRIT_RICE && !firstOrSinglePacket) {
+                    int missedPackets = lastMSDU.PacketNumber - msdu.PacketNumber - 1;
+
+                    if (lastMSDU.PacketNumber == 16383 && msdu.PacketNumber == 0) {
+                        missedPackets = 0;
+                    }
+
+                    if (missedPackets > 0)  {
+                        UIConsole.GlobalConsole.Warn(String.Format("Missed {0} packets on image. Filling with null bytes. Last Packet Number: {1} Current: {2}", missedPackets, lastMSDU.PacketNumber, msdu.PacketNumber));
+                        byte[] fill = PacketManager.GenerateFillData(fileHeader.ImageStructureHeader.Columns);
+                        using (FileStream fs = new FileStream(filename, FileMode.Append, FileAccess.Write)) {
+                            using (BinaryWriter sw = new BinaryWriter(fs)) {
+                                while (missedPackets > 0) {
+                                    sw.Write(fill);
+                                    missedPackets--;
+                                }
+                                sw.Flush();
+                            }
+                        }
+                    }
+                    dataToSave = PacketManager.InMemoryDecompress(dataToSave, fileHeader.ImageStructureHeader.Columns, fileHeader.RiceCompressionHeader.Pixel, fileHeader.RiceCompressionHeader.Flags);
                 }
 
-                using (FileStream fs = new FileStream(filename, firstOrSinglePacket || fileHeader.Compression == CompressionType.LRIT_RICE ? FileMode.Create : FileMode.Append, FileAccess.Write)) {
+                lastMSDU = msdu;
+
+                using (FileStream fs = new FileStream(filename, firstOrSinglePacket ? FileMode.Create : FileMode.Append, FileAccess.Write)) {
                     using (BinaryWriter sw = new BinaryWriter(fs)) {
-                        byte[] dataToSave = msdu.Data.Skip(firstOrSinglePacket ? 10 : 0).Take(firstOrSinglePacket ? msdu.PacketLength - 10 : msdu.PacketLength).ToArray(); 
                         sw.Write(dataToSave);
                         sw.Flush();
                     }
                 }
 
                 if (msdu.Sequence == SequenceType.LAST_SEGMENT || msdu.Sequence == SequenceType.SINGLE_DATA) {
-                    if (fileHeader.Compression == CompressionType.LRIT_RICE) { // # Rice
-                        string decompressed;
-                        if (msdu.Sequence == SequenceType.SINGLE_DATA) {
-                            decompressed = PacketManager.Decompressor(filename, fileHeader.ImageStructureHeader.Columns, fileHeader.RiceCompressionHeader.Pixel, fileHeader.RiceCompressionHeader.Flags);
-                        } else {
-                            decompressed = PacketManager.Decompressor(String.Format("channels/{0}/{1}_{2}_", channelId, msdu.APID, msdu.Version), fileHeader.ImageStructureHeader.Columns, startnum, endnum, fileHeader.RiceCompressionHeader.Pixel, fileHeader.RiceCompressionHeader.Flags);
-                        }
-
-                        FileHandler.HandleFile(decompressed, fileHeader);
-                        startnum = -1;
-                        endnum = -1;
-                    } else {
-                        FileHandler.HandleFile(filename, fileHeader);
-                        startnum = -1;
-                        endnum = -1;
-                    }
+                    FileHandler.HandleFile(filename, fileHeader);
+                    startnum = -1;
+                    endnum = -1;
                 }
             } catch (Exception e) {
                 UIConsole.GlobalConsole.Error(String.Format("Exception on FinishMSDU: {0}", e));

--- a/goesdump/ChannelDecoder/Demuxer.cs
+++ b/goesdump/ChannelDecoder/Demuxer.cs
@@ -147,6 +147,7 @@ namespace OpenSatelliteProject {
                     using (BinaryWriter sw = new BinaryWriter(fs)) {
                         byte[] dataToSave = msdu.Data.Skip(firstOrSinglePacket ? 10 : 0).Take(firstOrSinglePacket ? msdu.PacketLength - 10 : msdu.PacketLength).ToArray(); 
                         sw.Write(dataToSave);
+                        sw.Flush();
                     }
                 }
 

--- a/goesdump/GOES Dumper.csproj
+++ b/goesdump/GOES Dumper.csproj
@@ -109,6 +109,7 @@
     <Compile Include="GoesDecoder\ImageManager.cs" />
     <Compile Include="WebManager\DirectoryHandler.cs" />
     <Compile Include="Models\ProgConfig.cs" />
+    <Compile Include="GoesDecoder\EMWIN.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/goesdump/GOES Dumper.csproj
+++ b/goesdump/GOES Dumper.csproj
@@ -78,6 +78,9 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/goesdump/GoesDecoder/EMWIN.cs
+++ b/goesdump/GoesDecoder/EMWIN.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Linq;
+using OpenSatelliteProject.PacketData;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace OpenSatelliteProject {
+    public class EMWIN {
+
+        public static EMWIN Ingestor;
+
+        static EMWIN() {
+            Ingestor = new EMWIN();
+        }
+
+        private static readonly int MAX_FRAME_SIZE = 1116;
+        private static readonly string FILLFILENAME = "PFFILLFILE.TXT";
+        private byte[] buffer;
+        private Dictionary<string, EmwinFile> files;
+
+        private EMWIN() {
+            buffer = new byte[0];
+            files = new Dictionary<string, EmwinFile>();
+        }
+
+        public void Process(byte[] inData) {
+            buffer = buffer.Concat(inData).ToArray();
+            var pos = FindSyncMarker(buffer);
+            if (pos == -1) {
+                if (buffer.Length > MAX_FRAME_SIZE * 3) {
+                    UIConsole.GlobalConsole.Warn(string.Format("EMWIN Buffer grown beyond {0}! This should happen. Clearing buffer.", MAX_FRAME_SIZE * 3));
+                    buffer = new byte[0];
+                }
+                return;
+            }
+
+            var data = buffer.Skip(pos + 6).Take(MAX_FRAME_SIZE - 6).ToArray(); // 12 for the syncMark
+
+            if (data.Length != MAX_FRAME_SIZE - 6) {
+                // Not Enough Data
+                return;
+            }
+
+            buffer = buffer.Skip(pos + MAX_FRAME_SIZE).ToArray();
+            if (data.Length > 0) {
+                var headerData = Encoding.GetEncoding("ISO-8859-1").GetString(data.Take(80).ToArray());
+                data = data.Skip(80).ToArray();
+
+                try {
+                    var header = new EMWINHeader(headerData);
+                    if (header.Filename.Equals(FILLFILENAME)) {
+                        return;
+                    }
+                    //UIConsole.GlobalConsole.Log(string.Format("Received {0}/{1} of {2}", header.PartNumber, header.PartTotal, header.Filename));
+                    if (header.PartNumber == 1) {
+                        if (files.ContainsKey(header.Filename)) {
+                            UIConsole.GlobalConsole.Warn(string.Format("Files already has a key for file {0}", header.Filename));
+                        } else {
+                            string newfilename = DateTime.Now.ToString("yyyyMMddHHmmssffff") + header.Filename;
+                            files.Add(header.Filename, new EmwinFile());
+                            files[header.Filename].Parts = header.PartTotal;
+                            files[header.Filename].Received = 0;
+                            files[header.Filename].Output = Path.Combine("channels", Path.Combine("tmp", newfilename));
+                        }
+                    }
+
+                    if (!files.ContainsKey(header.Filename)) {
+                        //UIConsole.GlobalConsole.Warn(string.Format("(EMWIN) Received incomplete part for {0}", header.Filename));
+                        return;
+                    } else if (files[header.Filename].Received + 1 != header.PartNumber) {
+                        //UIConsole.GlobalConsole.Error(string.Format("(EMWIN) Missed {0} frames for file {1}", header.PartNumber - files[header.Filename].Received - 1, header.Filename));
+                        files.Remove(header.Filename);
+                        return;
+                    } else {
+                        string dir = Path.GetDirectoryName(files[header.Filename].Output);
+                        if (!Directory.Exists(dir)) {
+                            Directory.CreateDirectory(dir);
+                        }
+
+                        var f = File.Open(files[header.Filename].Output, header.PartNumber == 1 ? FileMode.Create : FileMode.Append);
+                        f.Write(data, 0, data.Length);
+                        f.Close();
+                        files[header.Filename].Received += 1;
+                    }
+
+                    if (header.PartNumber == header.PartTotal && files.ContainsKey(header.Filename)) {
+                        string output = files[header.Filename].Output;
+                        string basedir = new DirectoryInfo(Path.GetDirectoryName(output)).Parent.FullName;
+                        string newdir = Path.Combine(basedir, "EMWIN");
+
+                        if (!Directory.Exists(newdir)) {
+                            Directory.CreateDirectory(newdir);
+                        }
+
+                        string fname = Path.Combine(newdir, header.Filename);
+                        if (File.Exists(fname)) {
+                            fname = DateTime.Now.ToString("yyyyMMddHHmmssffff") + "-" + header.Filename;
+                            fname = Path.Combine(newdir, fname);
+                        }
+                        File.Move(files[header.Filename].Output, fname);
+                        UIConsole.GlobalConsole.Log(string.Format("New EMWIN ({0})", header.Filename));
+                        files.Remove(header.Filename);
+                        if (fname.Contains(".ZIS")) {
+                            PacketManager.ExtractZipFile(fname);
+                        }
+                    }
+                } catch (Exception e) {
+                    UIConsole.GlobalConsole.Error(string.Format("(EMWIN) Error: {0}", e.Message));
+                }
+            }
+        }
+
+        private static int FindSyncMarker(byte[] data) {
+            // The sync marker is 6 null bytes. We check for 6 null and a '/'
+            // Because sometimes there is null bytes in the middle of a packet.
+            int searchSize = data.Length - 7;
+            int pos = -1;
+
+            for (int i = 0; i < searchSize; i++) {
+                bool t = true;
+                for (int z = 0; z < 7; z++) {
+                    if (z == 6) {
+                        if (data[i + z] != '/') {
+                            t = false;
+                            break;
+                        }
+                    } else {
+                        if (data[i + z] != '\x00') {
+                            t = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (t) {
+                    pos = i;
+                    break;
+                }
+            }
+
+            return pos;
+        } 
+    }
+}
+

--- a/goesdump/GoesDecoder/ImageManager.cs
+++ b/goesdump/GoesDecoder/ImageManager.cs
@@ -130,21 +130,21 @@ namespace OpenSatelliteProject {
                             } else {
                                 if (ImageManager.GenerateVisible && mData.Visible.IsComplete && mData.Visible.MaxSegments != 0 && !mData.IsVisibleProcessed) {
                                     var bmp = ImageTools.GenerateFullImage(mData.Visible);
-                                    bmp.Save(string.Format("{0}-{1}-{2}-{3}.jpg", mData.SatelliteName, mData.RegionName, "VIS", z.Key), ImageFormat.Jpeg);
+                                    bmp.Save(Path.Combine(folder, string.Format("{0}-{1}-{2}-{3}.jpg", mData.SatelliteName, mData.RegionName, "VIS", z.Key)), ImageFormat.Jpeg);
                                     bmp.Dispose();
                                     mData.IsVisibleProcessed = true;
                                 }
 
                                 if (ImageManager.GenerateInfrared && mData.Infrared.IsComplete && mData.Infrared.MaxSegments != 0 && !mData.IsInfraredProcessed) {
                                     var bmp = ImageTools.GenerateFullImage(mData.Infrared);
-                                    bmp.Save(string.Format("{0}-{1}-{2}-{3}.jpg", mData.SatelliteName, mData.RegionName, "IR", z.Key), ImageFormat.Jpeg);
+                                    bmp.Save(Path.Combine(folder, string.Format("{0}-{1}-{2}-{3}.jpg", mData.SatelliteName, mData.RegionName, "IR", z.Key)), ImageFormat.Jpeg);
                                     bmp.Dispose();
                                     mData.IsInfraredProcessed = true;
                                 }
 
                                 if (ImageManager.GenerateWaterVapour && mData.WaterVapour.IsComplete && mData.WaterVapour.MaxSegments != 0 && !mData.IsWaterVapourProcessed) {
                                     var bmp = ImageTools.GenerateFullImage(mData.WaterVapour);
-                                    bmp.Save(string.Format("{0}-{1}-{2}-{3}.jpg", mData.SatelliteName, mData.RegionName, "WV", z.Key), ImageFormat.Jpeg);
+                                    bmp.Save(Path.Combine(folder, string.Format("{0}-{1}-{2}-{3}.jpg", mData.SatelliteName, mData.RegionName, "WV", z.Key)), ImageFormat.Jpeg);
                                     bmp.Dispose();
                                     mData.IsWaterVapourProcessed = true;
                                 }

--- a/goesdump/GoesDecoder/PacketManager.cs
+++ b/goesdump/GoesDecoder/PacketManager.cs
@@ -344,6 +344,33 @@ namespace OpenSatelliteProject {
             return f.Replace("." + newExt, ".lrit");
         }
 
+        public static byte[] GenerateFillData(int pixels) {
+            byte[] outputData = new byte[pixels];
+
+            for (int i = 0; i < pixels; i++) {
+                outputData[i] = 0x00;
+            }
+
+            return outputData;
+        }
+
+        public static byte[] InMemoryDecompress(byte[] compressedData, int pixels, int pixelsPerBlock, int mask) {
+            byte[] outputData = GenerateFillData(pixels);
+
+            try {
+                AEC.LritRiceDecompress(ref outputData, compressedData, 8, pixelsPerBlock, pixels, mask);
+            } catch (Exception e) {
+                if (e is AECException) {
+                    AECException aece = (AECException)e;
+                    UIConsole.GlobalConsole.Error(string.Format("AEC Decompress Error: {0}", aece.status.ToString()));
+                } else {
+                    UIConsole.GlobalConsole.Error(string.Format("Decompress error: {0}", e.ToString()));
+                }
+            }
+
+            return outputData;
+        }
+
         public static string Decompressor(string filename, int pixels, int pixelsPerBlock, int mask) {
             /**
              *  Temporary Workarround. Needs to change directly on Demuxer

--- a/goesdump/GoesDecoder/PacketManager.cs
+++ b/goesdump/GoesDecoder/PacketManager.cs
@@ -293,7 +293,7 @@ namespace OpenSatelliteProject {
             File.Move(filename, f.Replace("." + newExt, ".lrit"));
         }
 
-        public static string Decompressor(string filename, int pixels) {
+        public static string Decompressor(string filename, int pixels, int pixelsPerBlock, int mask) {
             /**
              *  Temporary Workarround. Needs to change directly on Demuxer
              */
@@ -306,7 +306,7 @@ namespace OpenSatelliteProject {
 
             try {
                 byte[] inputData = File.ReadAllBytes(filename);
-                AEC.LritRiceDecompress(ref outputData, inputData, 8, 16, pixels, AEC.ALLOW_K13_OPTION_MASK | AEC.MSB_OPTION_MASK | AEC.NN_OPTION_MASK);
+                AEC.LritRiceDecompress(ref outputData, inputData, 8, pixelsPerBlock, pixels, mask); //  AEC.ALLOW_K13_OPTION_MASK | AEC.MSB_OPTION_MASK | AEC.NN_OPTION_MASK
                 File.Delete(filename);
             } catch (Exception e) {
                 if (e is AECException) {
@@ -322,7 +322,7 @@ namespace OpenSatelliteProject {
         }
 
 
-        public static string Decompressor(string prefix, int pixels, int startnum, int endnum) {
+        public static string Decompressor(string prefix, int pixels, int startnum, int endnum, int pixelsPerBlock, int mask) {
             /**
              *  Temporary Workarround. Needs to change directly on Demuxer
              */
@@ -355,11 +355,11 @@ namespace OpenSatelliteProject {
                     }
 
                     try {
-                        AEC.LritRiceDecompress(ref outputData, input, 8, 16, pixels, AEC.ALLOW_K13_OPTION_MASK | AEC.MSB_OPTION_MASK | AEC.NN_OPTION_MASK);
+                        AEC.LritRiceDecompress(ref outputData, input, 8, pixelsPerBlock, pixels, mask);
                         File.Delete(ifile);
                     } catch (AECException e) {
                         Console.WriteLine("AEC Decompress problem decompressing file {0}: {1}", ifile, e.status.ToString());
-                        Console.WriteLine("AEC Params: {0} - {1} - {2}", 8, 16, pixels);
+                        Console.WriteLine("AEC Params: {0} - {1} - {2} - {3}", 8, pixelsPerBlock, pixels, mask);
                     }
 
                     f.Write(outputData, 0, outputData.Length);
@@ -374,7 +374,7 @@ namespace OpenSatelliteProject {
                         }
 
                         try {
-                            AEC.LritRiceDecompress(ref outputData, input, 8, 16, pixels, AEC.ALLOW_K13_OPTION_MASK | AEC.MSB_OPTION_MASK | AEC.NN_OPTION_MASK);
+                            AEC.LritRiceDecompress(ref outputData, input, 8, pixelsPerBlock, pixels, mask);
                             File.Delete(ifile);
                         } catch (AECException e) {
                             Console.WriteLine("AEC Decompress problem decompressing file {0}", ifile);

--- a/goesdump/GoesDecoder/PacketManager.cs
+++ b/goesdump/GoesDecoder/PacketManager.cs
@@ -37,9 +37,9 @@ namespace OpenSatelliteProject {
         public static string GetFolderByProduct(NOAAProductID product, int subProduct) {
             // TODO: Unify with other functions that use the same thing
             string folderName = UnknownDataFolder;
-            if (product == NOAAProductID.SCANNER_DATA_3) {
+            if (product == NOAAProductID.GOES16_ABI) {
                 folderName = Path.Combine(ImagesFolder, "FM1");
-            } else  if (product == NOAAProductID.SCANNER_DATA_1 || product == NOAAProductID.SCANNER_DATA_2) {
+            } else  if (product == NOAAProductID.GOES13_ABI || product == NOAAProductID.GOES15_ABI) {
                 switch (subProduct) {
                     case (int)ScannerSubProduct.INFRARED_AREA_OF_INTEREST:
                     case (int)ScannerSubProduct.VISIBLE_AREA_OF_INTEREST:
@@ -103,9 +103,11 @@ namespace OpenSatelliteProject {
             if (product != null && product.ID != -1) {
                 // New way
                 string folderName = UnknownDataFolder;
-                if (product.ID == (int)NOAAProductID.SCANNER_DATA_3) {
+                if (product.ID == (int)NOAAProductID.GOES16_ABI) {
                     folderName = Path.Combine(ImagesFolder, "FM1");
-                } else if (product.ID == (int)NOAAProductID.SCANNER_DATA_1 || product.ID == (int)NOAAProductID.SCANNER_DATA_2) {
+                } else if (product.ID == (int)NOAAProductID.HIMAWARI8_ABI) {
+                    folderName = Path.Combine(ImagesFolder, "Full Disk");
+                } else if (product.ID == (int)NOAAProductID.GOES13_ABI || product.ID == (int)NOAAProductID.GOES15_ABI) {
                     switch (subProduct.ID) {
                         case (int)ScannerSubProduct.INFRARED_AREA_OF_INTEREST:
                         case (int)ScannerSubProduct.VISIBLE_AREA_OF_INTEREST:

--- a/goesdump/GoesDecoder/PacketManager.cs
+++ b/goesdump/GoesDecoder/PacketManager.cs
@@ -224,8 +224,6 @@ namespace OpenSatelliteProject {
                 using (ZipInputStream s = new ZipInputStream(File.OpenRead(zipfile))) {
                     ZipEntry theEntry;
                     while ((theEntry = s.GetNextEntry()) != null) {
-                        Console.WriteLine(theEntry.Name);
-
                         string directoryName = Path.GetDirectoryName(theEntry.Name);
                         string fileName      = Path.GetFileName(theEntry.Name);
                         string baseFileName  = Path.GetFileName(theEntry.Name);

--- a/goesdump/GoesDecoder/PacketManager.cs
+++ b/goesdump/GoesDecoder/PacketManager.cs
@@ -254,9 +254,11 @@ namespace OpenSatelliteProject {
                             using (FileStream streamWriter = File.Create(fileName)) {
 
                                 int size = 2048;
+                                int readBytes = 0;
                                 byte[] data = new byte[2048];
-                                while (true) {
+                                while (readBytes < s.Length) {
                                     size = s.Read(data, 0, data.Length);
+                                    readBytes+= size;
                                     if (size > 0) {
                                         streamWriter.Write(data, 0, size);
                                     } else {

--- a/goesdump/HeadlessMain.cs
+++ b/goesdump/HeadlessMain.cs
@@ -102,27 +102,27 @@ namespace OpenSatelliteProject {
             }
 
             if (config.GenerateFDFalseColor) {
-                string fdFolder = PacketManager.GetFolderByProduct(NOAAProductID.SCANNER_DATA_1, (int)ScannerSubProduct.INFRARED_FULLDISK);
+                string fdFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_FULLDISK);
                 FDImageManager = new ImageManager(Path.Combine("channels", fdFolder));
             }
 
             if (config.GenerateXXFalseColor) {
-                string xxFolder = PacketManager.GetFolderByProduct(NOAAProductID.SCANNER_DATA_1, (int)ScannerSubProduct.INFRARED_AREA_OF_INTEREST);
+                string xxFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_AREA_OF_INTEREST);
                 XXImageManager = new ImageManager(Path.Combine("channels", xxFolder));
             }
 
             if (config.GenerateNHFalseColor) {
-                string nhFolder = PacketManager.GetFolderByProduct(NOAAProductID.SCANNER_DATA_1, (int)ScannerSubProduct.INFRARED_NORTHERN);
+                string nhFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_NORTHERN);
                 NHImageManager = new ImageManager(Path.Combine("channels", nhFolder));
             }
 
             if (config.GenerateSHFalseColor) {
-                string shFolder = PacketManager.GetFolderByProduct(NOAAProductID.SCANNER_DATA_1, (int)ScannerSubProduct.INFRARED_SOUTHERN);
+                string shFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_SOUTHERN);
                 SHImageManager = new ImageManager(Path.Combine("channels", shFolder));
             }
 
             if (config.GenerateUSFalseColor) {
-                string usFolder = PacketManager.GetFolderByProduct(NOAAProductID.SCANNER_DATA_1, (int)ScannerSubProduct.INFRARED_UNITEDSTATES);
+                string usFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_UNITEDSTATES);
                 USImageManager = new ImageManager(Path.Combine("channels", usFolder));
             }
 

--- a/goesdump/HeadlessMain.cs
+++ b/goesdump/HeadlessMain.cs
@@ -130,6 +130,7 @@ namespace OpenSatelliteProject {
 
             mtx = new Mutex();
             cn = new Connector();
+            DemuxManager.RecordToFile = true;
             demuxManager = new DemuxManager();
             cn.StatisticsAvailable += (Statistics_st data) => {
                 mtx.WaitOne();

--- a/goesdump/packages.config
+++ b/goesdump/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="WebSocketSharp" version="1.0.3-rc11" targetFramework="net45" />
   <package id="websocket-sharp.clone" version="3.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
* Added Dump Demux data
* Added PixelsPerBlock and Mask from File Header instead hardcoded.
* Added GOES-16 HRIT types. Bug Fixes
  * Fixed Sharing Violation Bug
  * Added GOES-16 HRIT Types ( Fixes #19 )
* Fixed some bugs and improved some features
  * Fixed a bug for replayFlag (it was breaking up files when duplicate packets arrived)
  * Changed Decompressor to fill with null bytes the expected image line if something fails
  * Improved incomplete file handler
* Fixed super-files bug
  * Fixed bug on big files that overflown the packet counter more than once and was overwritting the disk temporary.
  * Added in-memory decompressing
  * Added direct dump to a single file
* Added workarround for generating G16 False Color Images
  * Fixed path bug on Generating Single IR/VIS/WV images
* Added Auto-extract EMWIN-H ZIP files
  * Please run NuGet to restore Packages and download SharpZipLib
* Added Himawari 8 handles from GOES 15
* Moved EMWIN Ingestor to this branch  …
  * Fixed sync size to 6 null bytes
  * Still doesn't work well, but better now.
  * Disabled by default on Demuxer.cs
* Added DCS Header Parser
  * Added Table List for DCS files on WebUI