### PR TITLE
Added better handler for File Deletion

### DIFF
--- a/XRIT/Models/GroupData.cs
+++ b/XRIT/Models/GroupData.cs
@@ -1,25 +1,67 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenSatelliteProject.Tools;
 
 namespace OpenSatelliteProject {
     public class GroupData {
+        /// <summary>
+        /// Timeout to remove lrit files if not processed.
+        /// Default: 2h
+        /// </summary>
+        private const int DATA_TIMEOUT = 2 * 3600; // 2h
+
         public string SatelliteName { get; set; }
         public string RegionName { get; set; }
         public DateTime FrameTime { get; set; }
         public OrganizerData Visible { get; set; }
         public OrganizerData Infrared { get; set; }
         public OrganizerData WaterVapour { get; set; }
+        public Dictionary<string, OrganizerData> OtherData { get; set; }
 
         public bool IsProcessed { get; set; }
         public bool IsFalseColorProcessed { get; set; }
         public bool IsVisibleProcessed { get; set; }
         public bool IsInfraredProcessed { get; set; }
         public bool IsWaterVapourProcessed { get; set; }
+        public bool IsOtherDataProcessed { get; set; }
         public bool CropImage { get; set; }
 
         public int RetryCount { get; set; }
         public bool Failed { get; set; }
 
-        public bool IsComplete { get { return Visible.IsComplete && Infrared.IsComplete && WaterVapour.IsComplete; } }
+        public bool IsComplete { get { 
+                return Visible.IsComplete && 
+                    Infrared.IsComplete && 
+                    WaterVapour.IsComplete && 
+                    OtherDataIsComplete; 
+            } 
+        }
+
+        private bool OtherDataIsComplete { 
+            get { 
+                return OtherData.Count == 0 || OtherData
+                    .Select(x => x.Value.IsComplete)
+                    .Aggregate((x, y) => x & y); 
+            } 
+        }
+
+        public bool Timeout {
+            get {
+                return (LLTools.Timestamp() - Created) > DATA_TIMEOUT;
+            }
+        }
+
+        public void ForceComplete() {
+            IsProcessed = true;
+            IsFalseColorProcessed = true;
+            IsVisibleProcessed= true;
+            IsInfraredProcessed = true;
+            IsWaterVapourProcessed = true;
+            IsOtherDataProcessed = true;
+        }
+
+        private int Created;
 
         public GroupData() {
             SatelliteName = "Unknown";
@@ -28,6 +70,7 @@ namespace OpenSatelliteProject {
             Visible = new OrganizerData();
             Infrared = new OrganizerData();
             WaterVapour = new OrganizerData();
+            OtherData = new Dictionary<string, OrganizerData>();
             IsFalseColorProcessed = false;
             IsVisibleProcessed = false;
             IsInfraredProcessed = false;
@@ -36,6 +79,7 @@ namespace OpenSatelliteProject {
             Failed = false;
             RetryCount = 0;
             CropImage = false;
+            Created = LLTools.Timestamp();
         }
 
         public override string ToString() {
@@ -46,6 +90,7 @@ namespace OpenSatelliteProject {
                 "Visible Segments: {3} ({4})\n" +
                 "Infrared Segments: {5} ({6})\n" +
                 "Water Vapour Segments: {7} ({8})\n" +
+                "Other Data {9} ({10})\n" +
                 "\n",
                 SatelliteName,
                 RegionName,
@@ -55,7 +100,9 @@ namespace OpenSatelliteProject {
                 Infrared.Segments.Count,
                 Infrared.IsComplete ? "Complete" : "Incomplete",
                 WaterVapour.Segments.Count,
-                WaterVapour.IsComplete ? "Complete" : "Incomplete"
+                WaterVapour.IsComplete ? "Complete" : "Incomplete",
+                OtherData.Count,
+                OtherDataIsComplete ? "Complete" : "Incomplete"
             );
         }
     }

--- a/XRIT/Models/OrganizerData.cs
+++ b/XRIT/Models/OrganizerData.cs
@@ -9,6 +9,7 @@ namespace OpenSatelliteProject {
         public float PixelAspect { get; set; }
         public int ColumnOffset { get; set; }
         public int MaxSegments;
+        public bool OK { get; set; }
 
         public OrganizerData() {
             Segments = new Dictionary<int, string>();
@@ -17,6 +18,7 @@ namespace OpenSatelliteProject {
             PixelAspect = -1;
             ColumnOffset = 0;
             MaxSegments = 1;
+            OK = false;
         }
 
         public bool IsComplete { get { return Segments.Count == MaxSegments; }}

--- a/XRIT/Tools/Organizer.cs
+++ b/XRIT/Tools/Organizer.cs
@@ -114,7 +114,11 @@ namespace OpenSatelliteProject {
                             if (satellite == "G16") {
                                 od = grp.Visible;
                             } else {
-                                Console.WriteLine("Unknown Channel {0}", channel);
+                                string p = $"{timestamp%1000}-{((NOAAProductID)header.Product.ID).ToString()}-{header.SubProduct.Name}";
+                                if (!grp.OtherData.ContainsKey(p)) {
+                                    grp.OtherData.Add(p, new OrganizerData());
+                                }
+                                od = grp.OtherData[p];
                             }
                             break;
                         case 3: // Water Vapour
@@ -143,8 +147,12 @@ namespace OpenSatelliteProject {
                             }
                             break;
                         default:
-                            //Console.WriteLine("Unknown Channel {0}", channel);
-                            continue;
+                            string z = $"{timestamp%1000}-{((NOAAProductID)header.Product.ID).ToString()}-{header.SubProduct.Name}";
+                            if (!grp.OtherData.ContainsKey(z)) {
+                                grp.OtherData.Add(z, new OrganizerData());
+                            }
+                            od = grp.OtherData[z];
+                            break;
                     } 
 
 
@@ -168,13 +176,6 @@ namespace OpenSatelliteProject {
                     alreadyProcessed.Add(file);
                 }
             }
-            /*
-            foreach (var i in groupData) {
-                var data = i.Value;
-                Console.WriteLine("Showing group({0}): ", i.Key);
-                Console.WriteLine(data.ToString());
-            }
-            */
         }
     }
 }

--- a/goesdump/GoesDecoder/FileHandler.cs
+++ b/goesdump/GoesDecoder/FileHandler.cs
@@ -50,7 +50,7 @@ namespace OpenSatelliteProject {
             string ofilename = fileHeader.Filename == null ? Path.GetFileName(filename) : fileHeader.Filename; 
             string f = PacketManager.FixFileFolder(dir, ofilename, fileHeader.Product, fileHeader.SubProduct);
 
-            if ((fileHeader.Product.ID == (int)NOAAProductID.DCS && SkipDCS) || (fileHeader.Product.ID == (int)NOAAProductID.EMWIN && SkipEMWIN)) {
+            if ((fileHeader.Product.ID == (int)NOAAProductID.DCS && SkipDCS) || (fileHeader.Product.ID == (int)NOAAProductID.EMWIN && SkipEMWIN) || (fileHeader.Product.ID == (int)NOAAProductID.HRIT_EMWIN_TEXT && SkipEMWIN)) {
                 try {
                     File.Delete(filename);
                 } catch (IOException e) {


### PR DESCRIPTION
*	Added support for generating `OtherImages` (Those that are not Visible, Infared, WaterVapour or False Color)

For the scenario where the False Color is disabled, after generation of each part
(Visible, Infrared, WaterVapour, OtherImages) the ImageManager will delete the files
used for the generation of the images. In the scenario where False Color is enabled,
It will wait until the False Color is generated to erase each part. In the case of images
that will not have either Visible or Infrared (so no posibility of generating False Color),
there will be a timeout of 2h to erase the files. If in 2 hours it doesn't generate the
required images, if EraseFiles is enabled, it will erase the corresponding .lrit files.

This closes #27