### PR TITLE
Decoupled temp and final file folders

### DIFF
--- a/XRIT/Tools/LLTools.cs
+++ b/XRIT/Tools/LLTools.cs
@@ -16,6 +16,19 @@ namespace OpenSatelliteProject.Tools {
             }
         }
 
+        public static bool TestFolderAccess(string folder) {
+            try {
+                if (!Directory.Exists(folder)) {
+                    Directory.CreateDirectory(folder);
+                }
+                File.WriteAllText(Path.Combine(folder, "deleteme.txt"), "Test, you can remove me");
+                File.Delete(Path.Combine(folder, "deleteme.txt"));
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
         public static string FixPathString(string path) {
             foreach (var c in Path.InvalidPathChars) {
                 path = path.Replace(c, '_');

--- a/goesdump/ChannelDecoder/Demuxer.cs
+++ b/goesdump/ChannelDecoder/Demuxer.cs
@@ -127,9 +127,10 @@ namespace OpenSatelliteProject {
 
                 if (msdu.Sequence == SequenceType.FIRST_SEGMENT || msdu.Sequence == SequenceType.SINGLE_DATA) {
                     if (startnum != -1) {
-                        UIConsole.GlobalConsole.Error("Received First Segment but last data wasn't finished! Forcing dump.");
+                        UIConsole.GlobalConsole.Warn("Received First Segment but last data wasn't finished! Forcing dump.");
                         // This can only happen for multi-segment file.
-                        filename = String.Format("channels/{0}/{1}_{2}.lrit", channelId, lastMSDU.APID, lastMSDU.Version);
+                        filename = Path.Combine(FileHandler.TemporaryFileFolder, channelId.ToString());
+                        filename = Path.Combine(filename, $"{lastMSDU.APID}_{lastMSDU.Version}.lrit");
                         FileHandler.HandleFile(filename, fileHeader, manager);
                         startnum = -1;
                         endnum = -1;
@@ -164,12 +165,12 @@ namespace OpenSatelliteProject {
                 }
                 */
 
-                string path = String.Format("channels/{0}", channelId);
+                string path = Path.Combine(FileHandler.TemporaryFileFolder, channelId.ToString());
                 if (!Directory.Exists(path)) {
                     Directory.CreateDirectory(path);
                 }
 
-                filename = String.Format("channels/{0}/{1}_{2}.lrit", channelId, msdu.APID, msdu.Version);
+                filename = Path.Combine(path, $"{msdu.APID}_{msdu.Version}.lrit");
 
                 byte[] dataToSave = msdu.Data.Skip(firstOrSinglePacket ? 10 : 0).Take(firstOrSinglePacket ? msdu.PacketLength - 10 : msdu.PacketLength).ToArray(); 
 

--- a/goesdump/GoesDecoder/FileHandler.cs
+++ b/goesdump/GoesDecoder/FileHandler.cs
@@ -15,6 +15,8 @@ namespace OpenSatelliteProject {
         public static bool SkipDCS { get; set; }
         public static bool SkipEMWIN { get; set; }
         public static bool SkipWeatherData { get; set; }
+        public static string TemporaryFileFolder { get; set; }
+        public static string FinalFileFolder { get; set; }
 
 
         static FileHandler() {
@@ -23,6 +25,11 @@ namespace OpenSatelliteProject {
             SkipDCS = false;
             SkipEMWIN = false;
             SkipWeatherData = false;
+
+            string baseFolder = Directory.GetCurrentDirectory();
+
+            TemporaryFileFolder = Path.Combine(baseFolder, "tmp");
+            FinalFileFolder = Path.Combine(baseFolder, "output");
         }
 
         public static void AttachByCompressionHandler(int compressionType, FileHandlerFunction handler) {

--- a/goesdump/GoesDecoder/PacketManager.cs
+++ b/goesdump/GoesDecoder/PacketManager.cs
@@ -93,12 +93,12 @@ namespace OpenSatelliteProject {
                         break;
                 }
             }
-            return folderName;
+            return Path.Combine(FileHandler.FinalFileFolder, folderName);
         }
 
         public static string FixFileFolder(string dir, string filename, NOAAProduct product, NOAASubproduct subProduct) {
             string filef = LLTools.FixPathString(filename);
-            string basedir = new DirectoryInfo(dir).Parent.FullName;
+            string basedir = FileHandler.FinalFileFolder;
 
             if (product != null && product.ID != -1) {
                 // New way
@@ -318,7 +318,7 @@ namespace OpenSatelliteProject {
                     }
                 }
             } else if (header.PrimaryHeader.FileType == FileTypeCode.IMAGE) {
-                string basedir = new DirectoryInfo(Path.GetDirectoryName(filename)).Parent.FullName;
+                string basedir = FileHandler.FinalFileFolder;
                 if (header.Product.ID == (int)NOAAProductID.OTHER_SATELLITES_1 || header.Product.ID == (int)NOAAProductID.OTHER_SATELLITES_2) {
                     basedir = Path.Combine(basedir, OtherSatellitesFolder);
                 } else {
@@ -352,7 +352,7 @@ namespace OpenSatelliteProject {
 
         public static void HandleTextData(string filename, XRITHeader header) {
             if (header.PrimaryHeader.FileType == FileTypeCode.TEXT) {
-                string basedir = new DirectoryInfo(Path.GetDirectoryName(filename)).Parent.FullName;
+                string basedir = FileHandler.FinalFileFolder;
                 basedir = Path.Combine(basedir, TextFolder);
 
                 try {

--- a/goesdump/HeadlessMain.cs
+++ b/goesdump/HeadlessMain.cs
@@ -25,6 +25,7 @@ namespace OpenSatelliteProject {
         private ImageManager NHImageManager;
         private ImageManager SHImageManager;
         private ImageManager USImageManager;
+        private ImageManager FMImageManager;
 
         private DirectoryHandler directoryHandler;
 
@@ -82,6 +83,23 @@ namespace OpenSatelliteProject {
             FileHandler.SkipEMWIN = !config.EnableEMWIN;
             FileHandler.SkipDCS = !config.EnableDCS;
             FileHandler.SkipWeatherData = !config.EnableWeatherData;
+
+            if (config.TemporaryFileFolder != null) {
+                if (!LLTools.TestFolderAccess(config.TemporaryFileFolder)) {
+                    UIConsole.GlobalConsole.Error($"Cannot write file to Temporary Folder {config.TemporaryFileFolder}");
+                    throw new ApplicationException($"Cannot write file to Temporary Folder {config.TemporaryFileFolder}");
+                }
+                FileHandler.TemporaryFileFolder = config.TemporaryFileFolder;
+            }
+
+            if (config.FinalFileFolder != null) {
+                if (!LLTools.TestFolderAccess(config.FinalFileFolder)) {
+                    UIConsole.GlobalConsole.Error($"Cannot write file to Final Folder {config.FinalFileFolder}");
+                    throw new ApplicationException($"Cannot write file to Final Folder {config.FinalFileFolder}");
+                }
+                FileHandler.FinalFileFolder = config.FinalFileFolder;
+            }
+
             ImageManager.EraseFiles = config.EraseFilesAfterGeneratingFalseColor;
             ImageManager.GenerateInfrared = config.GenerateInfraredImages;
             ImageManager.GenerateVisible = config.GenerateVisibleImages;
@@ -106,32 +124,21 @@ namespace OpenSatelliteProject {
                 }
             }
 
-            if (config.GenerateFDFalseColor) {
-                string fdFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_FULLDISK);
-                FDImageManager = new ImageManager(Path.Combine("channels", fdFolder));
-            }
+            string fdFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_FULLDISK);
+            string xxFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_AREA_OF_INTEREST);
+            string nhFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_NORTHERN);
+            string shFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_SOUTHERN);
+            string usFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_UNITEDSTATES);
+            string fmFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES16_ABI, (int)ScannerSubProduct.NONE);
 
-            if (config.GenerateXXFalseColor) {
-                string xxFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_AREA_OF_INTEREST);
-                XXImageManager = new ImageManager(Path.Combine("channels", xxFolder));
-            }
+            FDImageManager = new ImageManager(fdFolder);
+            XXImageManager = new ImageManager(xxFolder);
+            NHImageManager = new ImageManager(nhFolder);
+            SHImageManager = new ImageManager(shFolder);
+            USImageManager = new ImageManager(usFolder);
+            FMImageManager = new ImageManager(fmFolder);
 
-            if (config.GenerateNHFalseColor) {
-                string nhFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_NORTHERN);
-                NHImageManager = new ImageManager(Path.Combine("channels", nhFolder));
-            }
-
-            if (config.GenerateSHFalseColor) {
-                string shFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_SOUTHERN);
-                SHImageManager = new ImageManager(Path.Combine("channels", shFolder));
-            }
-
-            if (config.GenerateUSFalseColor) {
-                string usFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_UNITEDSTATES);
-                USImageManager = new ImageManager(Path.Combine("channels", usFolder));
-            }
-
-            directoryHandler = new DirectoryHandler("channels", "/data");
+            directoryHandler = new DirectoryHandler(FileHandler.FinalFileFolder, "/data");
 
             mtx = new Mutex();
             cn = new Connector();
@@ -226,21 +233,12 @@ namespace OpenSatelliteProject {
 
             UIConsole.GlobalConsole.Log("Headless Main Starting");
 
-            if (config.GenerateFDFalseColor) {
-                FDImageManager.Start();
-            }
-            if (config.GenerateXXFalseColor) {
-                XXImageManager.Start();
-            }
-            if (config.GenerateNHFalseColor) {
-                NHImageManager.Start();
-            }
-            if (config.GenerateSHFalseColor) {
-                SHImageManager.Start();
-            }
-            if (config.GenerateUSFalseColor) {
-                USImageManager.Start();
-            }
+            FDImageManager.Start();
+            XXImageManager.Start();
+            NHImageManager.Start();
+            SHImageManager.Start();
+            USImageManager.Start();
+            FMImageManager.Start();
 
             cn.Start();
             httpsv.Start();
@@ -254,21 +252,12 @@ namespace OpenSatelliteProject {
             cn.Stop();
             httpsv.Stop();
 
-            if (config.GenerateFDFalseColor) {
-                FDImageManager.Stop();
-            }
-            if (config.GenerateXXFalseColor) {
-                XXImageManager.Stop();
-            }
-            if (config.GenerateNHFalseColor) {
-                NHImageManager.Stop();
-            }
-            if (config.GenerateSHFalseColor) {
-                SHImageManager.Stop();
-            }
-            if (config.GenerateUSFalseColor) {
-                USImageManager.Stop();
-            }
+            FDImageManager.Stop();
+            XXImageManager.Stop();
+            NHImageManager.Stop();
+            SHImageManager.Stop();
+            USImageManager.Stop();
+            FMImageManager.Stop();
         }
     }
 }

--- a/goesdump/Main.cs
+++ b/goesdump/Main.cs
@@ -24,6 +24,7 @@ namespace OpenSatelliteProject {
         private ImageManager NHImageManager;
         private ImageManager SHImageManager;
         private ImageManager USImageManager;
+        private ImageManager FMImageManager;
 
         GraphicsDeviceManager graphics;
         SpriteBatch spriteBatch;
@@ -88,6 +89,23 @@ namespace OpenSatelliteProject {
             FileHandler.SkipEMWIN = !config.EnableEMWIN;
             FileHandler.SkipDCS = !config.EnableDCS;
             FileHandler.SkipWeatherData = !config.EnableWeatherData;
+
+            if (config.TemporaryFileFolder != null) {
+                if (!LLTools.TestFolderAccess(config.TemporaryFileFolder)) {
+                    UIConsole.GlobalConsole.Error($"Cannot write file to Temporary Folder {config.TemporaryFileFolder}");
+                    throw new ApplicationException($"Cannot write file to Temporary Folder {config.TemporaryFileFolder}");
+                }
+                FileHandler.TemporaryFileFolder = config.TemporaryFileFolder;
+            }
+
+            if (config.FinalFileFolder != null) {
+                if (!LLTools.TestFolderAccess(config.FinalFileFolder)) {
+                    UIConsole.GlobalConsole.Error($"Cannot write file to Final Folder {config.FinalFileFolder}");
+                    throw new ApplicationException($"Cannot write file to Final Folder {config.FinalFileFolder}");
+                }
+                FileHandler.FinalFileFolder = config.FinalFileFolder;
+            }
+
             ImageManager.EraseFiles = config.EraseFilesAfterGeneratingFalseColor;
             ImageManager.GenerateInfrared = config.GenerateInfraredImages;
             ImageManager.GenerateVisible = config.GenerateVisibleImages;
@@ -112,30 +130,19 @@ namespace OpenSatelliteProject {
                 }
             }
 
-            if (config.GenerateFDFalseColor) {
-                string fdFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_FULLDISK);
-                FDImageManager = new ImageManager(Path.Combine("channels", fdFolder));
-            }
+            string fdFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_FULLDISK);
+            string xxFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_AREA_OF_INTEREST);
+            string nhFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_NORTHERN);
+            string shFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_SOUTHERN);
+            string usFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_UNITEDSTATES);
+            string fmFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES16_ABI, (int)ScannerSubProduct.NONE);
 
-            if (config.GenerateXXFalseColor) {
-                string xxFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_AREA_OF_INTEREST);
-                XXImageManager = new ImageManager(Path.Combine("channels", xxFolder));
-            }
-
-            if (config.GenerateNHFalseColor) {
-                string nhFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_NORTHERN);
-                NHImageManager = new ImageManager(Path.Combine("channels", nhFolder));
-            }
-
-            if (config.GenerateSHFalseColor) {
-                string shFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_SOUTHERN);
-                SHImageManager = new ImageManager(Path.Combine("channels", shFolder));
-            }
-
-            if (config.GenerateUSFalseColor) {
-                string usFolder = PacketManager.GetFolderByProduct(NOAAProductID.GOES13_ABI, (int)ScannerSubProduct.INFRARED_UNITEDSTATES);
-                USImageManager = new ImageManager(Path.Combine("channels", usFolder));
-            }
+            FDImageManager = new ImageManager(fdFolder);
+            XXImageManager = new ImageManager(xxFolder);
+            NHImageManager = new ImageManager(nhFolder);
+            SHImageManager = new ImageManager(shFolder);
+            USImageManager = new ImageManager(usFolder);
+            FMImageManager = new ImageManager(fmFolder);
         }
 
         /// <summary>
@@ -172,21 +179,12 @@ namespace OpenSatelliteProject {
             statistics = new Statistics_st();
             cn.Start();
 
-            if (config.GenerateFDFalseColor) {
-                FDImageManager.Start();
-            }
-            if (config.GenerateXXFalseColor) {
-                XXImageManager.Start();
-            }
-            if (config.GenerateNHFalseColor) {
-                NHImageManager.Start();
-            }
-            if (config.GenerateSHFalseColor) {
-                SHImageManager.Start();
-            }
-            if (config.GenerateUSFalseColor) {
-                USImageManager.Start();
-            }
+            FDImageManager.Start();
+            XXImageManager.Start();
+            NHImageManager.Start();
+            SHImageManager.Start();
+            USImageManager.Start();
+            FMImageManager.Start();
         }
 
         /// <summary>
@@ -297,21 +295,12 @@ namespace OpenSatelliteProject {
         protected override void OnExiting(object sender, EventArgs args) {
             base.OnExiting(sender, args);
             cn.Stop();
-            if (config.GenerateFDFalseColor) {
-                FDImageManager.Stop();
-            }
-            if (config.GenerateXXFalseColor) {
-                XXImageManager.Stop();
-            }
-            if (config.GenerateNHFalseColor) {
-                NHImageManager.Stop();
-            }
-            if (config.GenerateSHFalseColor) {
-                SHImageManager.Stop();
-            }
-            if (config.GenerateUSFalseColor) {
-                USImageManager.Stop();
-            }
+            FDImageManager.Stop();
+            XXImageManager.Stop();
+            NHImageManager.Stop();
+            SHImageManager.Stop();
+            USImageManager.Stop();
+            FMImageManager.Stop();
             Environment.Exit(Environment.ExitCode);
         }
     }

--- a/goesdump/Models/ProgConfig.cs
+++ b/goesdump/Models/ProgConfig.cs
@@ -13,6 +13,20 @@ namespace OpenSatelliteProject {
         }
         #endregion
 
+        #region Folders
+        [UserScopedSettingAttribute()]
+        public string TemporaryFileFolder {
+            get { return (string)this["TemporaryFileFolder"]; }
+            set { this["TemporaryFileFolder"] = value; }
+        }
+
+        [UserScopedSettingAttribute()]
+        public string FinalFileFolder {
+            get { return (string)this["FinalFileFolder"]; }
+            set { this["FinalFileFolder"] = value; }
+        }
+        #endregion
+
         #region Decoder Data
 
         [UserScopedSettingAttribute()]


### PR DESCRIPTION
*	Decoupled temp and final file folders.
*	The final files will default go to `output` and temporary files to `tmp`
*	Added ability to change this folders in the config file by editing the parameters `TemporaryFileFolder` and `FinalFileFolder`
*	One of the features suggested by @hwboy4 on OSP Rocketchat in #9