### PR TITLE
Fixed timestamp for GOES-N series

### DIFF
--- a/XRIT/Tools/Organizer.cs
+++ b/XRIT/Tools/Organizer.cs
@@ -82,7 +82,7 @@ namespace OpenSatelliteProject {
                                     var seconds = dtstring.Substring(15, 2);
                                     //Console.WriteLine("Year: {0}\nDay Of Year: {1}\nHours: {2}\nMinutes: {3}\nSeconds: {4}", year, dayOfYear, hours, minutes, seconds);
                                     datetime = new DateTime(int.Parse(year), 1, 1, int.Parse(hours), int.Parse(minutes), int.Parse(seconds));
-                                    datetime = datetime.AddDays(int.Parse(dayOfYear));
+                                    datetime = datetime.AddDays(int.Parse(dayOfYear) - 1);
                                 } else {
                                     datetime = DateTime.Parse(dtstring, null, DateTimeStyles.RoundtripKind);
                                 }


### PR DESCRIPTION
Unix epoch timestamps for GOES-N series were 1 day ahead of actual time of frame start. Subtracted day by 1